### PR TITLE
Remove Prefect-managed integration libraries to archived from the integrations catalog

### DIFF
--- a/docs/integrations/catalog/prefect-airbyte.yaml
+++ b/docs/integrations/catalog/prefect-airbyte.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-airbyte
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-airbyte/
-iconUrl: /img/collections/airbyte.png
-tag: Airbyte

--- a/docs/integrations/catalog/prefect-census.yaml
+++ b/docs/integrations/catalog/prefect-census.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-census
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-census/
-iconUrl: /img/collections/census.png
-tag: Census

--- a/docs/integrations/catalog/prefect-firebolt.yaml
+++ b/docs/integrations/catalog/prefect-firebolt.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-firebolt
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-firebolt/
-iconUrl: /img/collections/firebolt.png
-tag: Firebolt

--- a/docs/integrations/catalog/prefect-great-expectations.yaml
+++ b/docs/integrations/catalog/prefect-great-expectations.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-great-expectations
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-great-expectations/
-iconUrl: /img/collections/ge.png
-tag: Great Expectations

--- a/docs/integrations/catalog/prefect-hex.yaml
+++ b/docs/integrations/catalog/prefect-hex.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-hex
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-hex/
-iconUrl: /img/collections/hex.png
-tag: Hex

--- a/docs/integrations/catalog/prefect-hightouch.yaml
+++ b/docs/integrations/catalog/prefect-hightouch.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-hightouch
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-hightouch/
-iconUrl: /img/collections/hightouch.png
-tag: Hightouch

--- a/docs/integrations/catalog/prefect-jupyter.yaml
+++ b/docs/integrations/catalog/prefect-jupyter.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-jupyter
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-jupyter/
-iconUrl: /img/collections/jupyter.png
-tag: Jupyter

--- a/docs/integrations/catalog/prefect-monday.yaml
+++ b/docs/integrations/catalog/prefect-monday.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-monday
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-monday/
-iconUrl: /img/collections/monday.png
-tag: Monday

--- a/docs/integrations/catalog/prefect-monte-carlo.yaml
+++ b/docs/integrations/catalog/prefect-monte-carlo.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-monte-carlo
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-monte-carlo/
-iconUrl: /img/collections/monte-carlo.png
-tag: MonteCarlo

--- a/docs/integrations/catalog/prefect-openai.yaml
+++ b/docs/integrations/catalog/prefect-openai.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-openai
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-openai/
-iconUrl: /img/collections/openai.png
-tag: OpenAI

--- a/docs/integrations/catalog/prefect-openmetadata.yaml
+++ b/docs/integrations/catalog/prefect-openmetadata.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-openmetadata
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-openmetadata/
-iconUrl: /img/collections/openmetadata.png
-tag: OpenMetadata

--- a/docs/integrations/catalog/prefect-sqlalchemy.yaml
+++ b/docs/integrations/catalog/prefect-sqlalchemy.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-sqlalchemy
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-sqlalchemy/
-iconUrl: /img/collections/sqlalchemy.png
-tag: SQLAlchemy

--- a/docs/integrations/catalog/prefect-twitter.yaml
+++ b/docs/integrations/catalog/prefect-twitter.yaml
@@ -1,6 +1,0 @@
-collectionName: prefect-twitter
-author: Prefect
-authorUrl: https://prefect.io
-documentation: https://prefecthq.github.io/prefect-twitter/
-iconUrl: /img/collections/twitter.png
-tag: Twitter


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#12781](https://togithub.com/PrefectHQ/prefect/pull/12781).



The original branch is upstream/docs/clean-up-integrations