### PR TITLE
Rename `read_automation_by_name` and return list of matching automations

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -3204,18 +3204,15 @@ class PrefectClient:
         response.raise_for_status()
         return Automation.parse_obj(response.json())
 
-    async def read_automation_by_name(self, name: str) -> Optional[Automation]:
+    async def read_automations_by_name(self, name: str) -> List[Automation]:
         """
         Query the Prefect API for an automation by name. Only automations matching the provided name will be returned.
-
-        If more than one automation matches the name, the most recently updated automation will be returned.
 
         Args:
             name: the name of the automation to query
 
         Returns:
-            an Automation model representation of the automation, or None if not found. If more than one automation
-            matches the name, the most recently updated automation will be returned.
+            a list of Automation model representations of the automations
         """
         if not self.server_type.supports_automations():
             self._raise_for_unsupported_automations()
@@ -3234,14 +3231,7 @@ class PrefectClient:
 
         response.raise_for_status()
 
-        if not response.json():
-            return None
-
-        else:
-            # normally a `/filter` endpoint would return a list of objects, but read_x_by_name
-            # methods return a single object in all other methods in the client, so
-            # we're ensuring parity there
-            return Automation.parse_obj(response.json()[0])
+        return pydantic.parse_obj_as(List[Automation], response.json())
 
     async def pause_automation(self, automation_id: UUID):
         if not self.server_type.supports_automations():

--- a/tests/client/test_prefect_client.py
+++ b/tests/client/test_prefect_client.py
@@ -2129,7 +2129,7 @@ class TestAutomations:
 
             assert read_route.called
 
-    async def test_read_automation_by_name(
+    async def test_read_automations_by_name(
         self, cloud_client, automation: AutomationCore
     ):
         with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
@@ -2138,16 +2138,18 @@ class TestAutomations:
             read_route = router.post("/automations/filter").mock(
                 return_value=httpx.Response(200, json=[created_automation])
             )
-            read_automation = await cloud_client.read_automation_by_name(
+            read_automation = await cloud_client.read_automations_by_name(
                 automation.name
             )
 
             assert read_route.called
-            assert isinstance(read_automation, AutomationCore)
-            assert read_automation.id == UUID(created_automation["id"])
-            assert read_automation.name == automation.name == created_automation["name"]
+            assert len(read_automation) == 1
+            assert read_automation[0].id == UUID(created_automation["id"])
+            assert (
+                read_automation[0].name == automation.name == created_automation["name"]
+            )
 
-    async def test_read_automation_by_name_not_found(
+    async def test_read_automations_by_name_not_found(
         self, cloud_client, automation: AutomationCore
     ):
         with respx.mock(base_url=PREFECT_CLOUD_API_URL.value()) as router:
@@ -2158,13 +2160,13 @@ class TestAutomations:
                 return_value=httpx.Response(200, json=[])
             )
 
-            nonexistent_automation = await cloud_client.read_automation_by_name(
+            nonexistent_automation = await cloud_client.read_automations_by_name(
                 name="nonexistent"
             )
 
             assert read_route.called
 
-            assert nonexistent_automation is None
+            assert nonexistent_automation == []
 
     async def test_delete_owned_automations_not_cloud_runtime_error(
         self, prefect_client

--- a/tests/events/server/models/test_automations.py
+++ b/tests/events/server/models/test_automations.py
@@ -59,7 +59,7 @@ async def test_reading_automations_by_workspace_by_name(
     ]
 
 
-async def test_reading_automation_by_workspace_by_name_filtered_match(
+async def test_reading_automations_by_workspace_by_name_filtered_match(
     automations_session: AsyncSession,
     some_workspace_automations: Sequence[Automation],
 ):
@@ -74,7 +74,7 @@ async def test_reading_automation_by_workspace_by_name_filtered_match(
     assert existing[0].name == "automation 2"
 
 
-async def test_reading_automation_by_workspace_by_name_filtered_mismatch(
+async def test_reading_automations_by_workspace_by_name_filtered_mismatch(
     automations_session: AsyncSession,
     some_workspace_automations: Sequence[Automation],
 ):


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#12884](https://togithub.com/PrefectHQ/prefect/pull/12884).



The original branch is upstream/return-list-in-read-automations-by-name