### PR TITLE
Avoid running the `prefect-client` build all the time

### DIFF
--- a/.github/workflows/prefect-client.yaml
+++ b/.github/workflows/prefect-client.yaml
@@ -2,6 +2,8 @@ name: Verify prefect-client build
 
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - "**/*.py"
       - requirements.txt
@@ -10,6 +12,11 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "**/*.py"
+      - requirements.txt
+      - requirements-client.txt
+      - setup.cfg
   workflow_call:
     inputs:
       upload-artifacts:


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#12984](https://togithub.com/PrefectHQ/prefect/pull/12984).



The original branch is upstream/avoid-extra-ci