### PR TITLE
Handle empty `service_account_info` for cached Vertex client

### DIFF
--- a/src/integrations/prefect-gcp/prefect_gcp/credentials.py
+++ b/src/integrations/prefect-gcp/prefect_gcp/credentials.py
@@ -90,7 +90,7 @@ class ClientType(Enum):
 @functools.lru_cache(maxsize=8, typed=True)
 def _get_job_service_async_client_cached(
     ctx, client_options: tuple
-) -> JobServiceAsyncClient:
+) -> "JobServiceAsyncClient":
     """
     Gets an authenticated Job Service async client for Vertex AI.
 
@@ -148,7 +148,9 @@ class GcpCredentials(CredentialsBlock):
         return hash(
             (
                 hash(self.service_account_file),
-                hash(frozenset(self.service_account_info.dict().items())),
+                hash(frozenset(self.service_account_info.dict().items()))
+                if self.service_account_info
+                else None,
                 hash(self.project),
                 hash(self._service_account_email),
             )

--- a/src/integrations/prefect-gcp/tests/test_credentials.py
+++ b/src/integrations/prefect-gcp/tests/test_credentials.py
@@ -198,6 +198,33 @@ async def test_get_job_service_async_client_cached(
     assert _get_job_service_async_client_cached.cache_info().hits == 2
 
 
+async def test_get_job_service_async_client_cached_from_file(
+    service_account_info, oauth2_credentials
+):
+    """
+    Test to ensure that _get_job_service_async_client_cached function returns the same instance
+    for multiple calls with the same parameters and properly utilizes lru_cache.
+    """
+    _get_job_service_async_client_cached.cache_clear()
+
+    project = "test_project"
+    credentials = GcpCredentials(
+        service_account_file=SERVICE_ACCOUNT_FILES[0],
+        project=project,
+    )
+
+    assert (
+        _get_job_service_async_client_cached.cache_info().hits == 0
+    ), "Initial call count should be 0"
+
+    credentials.get_job_service_async_client(client_options={})
+    credentials.get_job_service_async_client(client_options={})
+    credentials.get_job_service_async_client(client_options={})
+
+    assert _get_job_service_async_client_cached.cache_info().misses == 1
+    assert _get_job_service_async_client_cached.cache_info().hits == 2
+
+
 class MockTargetConfigs(Block):
     credentials: GcpCredentials
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13175](https://togithub.com/PrefectHQ/prefect/pull/13175).



The original branch is upstream/vertex-fixes