### PR TITLE
stop gating `Task.serve` with experimental flag

### DIFF
--- a/src/prefect/task_server.py
+++ b/src/prefect/task_server.py
@@ -21,7 +21,6 @@ from prefect.logging.loggers import get_logger
 from prefect.results import ResultFactory
 from prefect.settings import (
     PREFECT_API_URL,
-    PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING,
     PREFECT_TASK_SCHEDULING_DELETE_FAILED_SUBMISSIONS,
 )
 from prefect.states import Pending
@@ -291,11 +290,6 @@ async def serve(*tasks: Task, task_runner: Optional[Type[BaseTaskRunner]] = None
             serve(say, yell)
         ```
     """
-    if not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING.value():
-        raise RuntimeError(
-            "To enable task scheduling, set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING"
-            " to True."
-        )
 
     task_server = TaskServer(*tasks, task_runner=task_runner)
     try:

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1073,12 +1073,6 @@ class Task(Generic[P, R]):
             >>> my_task.serve()
         """
 
-        if not PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING:
-            raise ValueError(
-                "Task's `serve` method is an experimental feature and must be enabled with "
-                "`prefect config set PREFECT_EXPERIMENTAL_ENABLE_TASK_SCHEDULING=True`"
-            )
-
         from prefect.task_server import serve
 
         serve(self, task_runner=task_runner)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13137](https://togithub.com/PrefectHQ/prefect/pull/13137).



The original branch is upstream/remove-gate-task-serve