### PR TITLE
Renaming `prefect.work-pool.not_ready` to `prefect.work-pool.not-ready`

### DIFF
--- a/docs/concepts/automations.md
+++ b/docs/concepts/automations.md
@@ -96,7 +96,7 @@ from prefect.events.schemas.automations import EventTrigger
 from prefect.server.events.actions import CancelFlowRun
 
 # creating an automation
-automation = 
+automation =
   Automation(
     name="woodchonk",
     trigger=EventTrigger(
@@ -112,7 +112,7 @@ automation =
         ).create()
 print(automation)
 # name='woodchonk' description='' enabled=True trigger=EventTrigger(type='event', match=ResourceSpecification(__root__={'genus': 'Marmota', 'species': 'monax'}), match_related=ResourceSpecification(__root__={}), after=set(), expect={'animal.walked'}, for_each=set(), posture=Posture.Reactive, threshold=3, within=datetime.timedelta(seconds=10)) actions=[CancelFlowRun(type='cancel-flow-run')] actions_on_trigger=[] actions_on_resolve=[] owner_resource=None id=UUID('d641c552-775c-4dc6-a31e-541cb11137a6')
-  
+
 # reading the automation
 
 automation = Automation.read(id ="d641c552-775c-4dc6-a31e-541cb11137a6")
@@ -553,7 +553,7 @@ Any type of trigger may be composed into higher-order composite triggers, includ
     {
       "type": "event",
       "posture": "Reactive",
-      "expect": ["prefect.work-pool.not_ready"],
+      "expect": ["prefect.work-pool.not-ready"],
       "match": {
         "prefect.resource.name": "kubernetes-workers",
       }

--- a/src/prefect/server/models/events.py
+++ b/src/prefect/server/models/events.py
@@ -402,9 +402,7 @@ async def work_pool_status_event(
     return Event(
         id=event_id,
         occurred=occurred,
-        # TODO: this should be
-        # event=f"prefect.work-pool.{work_pool.status.in_kebab_case()}",
-        event=f"prefect.work-pool.{work_pool.status.value.lower()}",
+        event=f"prefect.work-pool.{work_pool.status.in_kebab_case()}",
         resource={
             "prefect.resource.id": f"prefect.work-pool.{work_pool.id}",
             "prefect.resource.name": work_pool.name,

--- a/tests/server/api/test_workers.py
+++ b/tests/server/api/test_workers.py
@@ -101,7 +101,7 @@ class TestCreateWorkPool:
         )
         assert model.name == "Pool 1"
 
-        assert_status_events("Pool 1", ["prefect.work-pool.not_ready"])
+        assert_status_events("Pool 1", ["prefect.work-pool.not-ready"])
 
     async def test_create_work_pool_with_options(self, client):
         response = await client.post(
@@ -326,7 +326,7 @@ class TestUpdateWorkPool:
         )
 
         assert_status_events(
-            work_pool.name, ["prefect.work-pool.paused", "prefect.work-pool.not_ready"]
+            work_pool.name, ["prefect.work-pool.paused", "prefect.work-pool.not-ready"]
         )
 
     async def test_unpause_work_pool_with_online_workers(self, client, work_pool):

--- a/tests/server/services/test_foreman.py
+++ b/tests/server/services/test_foreman.py
@@ -279,7 +279,7 @@ class TestForeman:
         assert len(events) == 1
 
         event = events[0]
-        assert event.event == "prefect.work-pool.not_ready"
+        assert event.event == "prefect.work-pool.not-ready"
         assert event.resource.id == f"prefect.work-pool.{ready_work_pool.id}"
         assert event.resource.name == ready_work_pool.name
         assert event.resource["prefect.work-pool.type"] == "test"
@@ -470,11 +470,11 @@ class TestForeman:
         for event in events:
             print(event.id, event.follows, event.event, event.resource.id)
 
-        assert events[0].event == "prefect.work-pool.not_ready"
+        assert events[0].event == "prefect.work-pool.not-ready"
         assert events[0].follows is None
         assert events[1].event == "prefect.work-pool.ready"
         assert events[1].follows == events[0].id
-        assert events[2].event == "prefect.work-pool.not_ready"
+        assert events[2].event == "prefect.work-pool.not-ready"
         assert events[2].follows == events[1].id
 
     async def test_status_update_when_deployment_has_old_last_polled_time(


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13202](https://togithub.com/PrefectHQ/prefect/pull/13202).



The original branch is upstream/rename-work-pool-not-ready