### PR TITLE
Bump vue-router from 4.3.0 to 4.3.2 in /ui

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,7 +18,7 @@
         "lodash.merge": "^4.6.2",
         "tailwindcss": "3.4.3",
         "vue": "3.4.26",
-        "vue-router": "4.3.0"
+        "vue-router": "4.3.2"
       },
       "devDependencies": {
         "@prefecthq/eslint-config": "1.0.32",
@@ -6366,9 +6366,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.0.tgz",
-      "integrity": "sha512-dqUcs8tUeG+ssgWhcPbjHvazML16Oga5w34uCUmsk7i0BcnskoLGwjpa15fqMr2Fa5JgVBrdL2MEgqz6XZ/6IQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.2.tgz",
+      "integrity": "sha512-hKQJ1vDAZ5LVkKEnHhmm1f9pMiWIBNGF5AwU67PdH7TyXCj/a4hTccuUuYCAMgJK6rO/NVYtQIEN3yL8CECa7Q==",
       "dependencies": {
         "@vue/devtools-api": "^6.5.1"
       },
@@ -10990,9 +10990,9 @@
       }
     },
     "vue-router": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.0.tgz",
-      "integrity": "sha512-dqUcs8tUeG+ssgWhcPbjHvazML16Oga5w34uCUmsk7i0BcnskoLGwjpa15fqMr2Fa5JgVBrdL2MEgqz6XZ/6IQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.3.2.tgz",
+      "integrity": "sha512-hKQJ1vDAZ5LVkKEnHhmm1f9pMiWIBNGF5AwU67PdH7TyXCj/a4hTccuUuYCAMgJK6rO/NVYtQIEN3yL8CECa7Q==",
       "requires": {
         "@vue/devtools-api": "^6.5.1"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,7 @@
     "lodash.merge": "^4.6.2",
     "tailwindcss": "3.4.3",
     "vue": "3.4.26",
-    "vue-router": "4.3.0"
+    "vue-router": "4.3.2"
   },
   "devDependencies": {
     "@prefecthq/eslint-config": "1.0.32",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13148](https://togithub.com/PrefectHQ/prefect/pull/13148).



The original branch is upstream/dependabot/npm_and_yarn/ui/vue-router-4.3.2