### PR TITLE
Support `timeout` on global concurrency limit slot acquisition

### DIFF
--- a/src/prefect/concurrency/asyncio.py
+++ b/src/prefect/concurrency/asyncio.py
@@ -30,21 +30,45 @@ class ConcurrencySlotAcquisitionError(Exception):
 async def concurrency(
     names: Union[str, List[str]], occupy: int = 1, timeout: Optional[float] = None
 ):
-    names = names if isinstance(names, list) else [names]
+    """A context manager that acquires and releases concurrency slots from the
+    given concurrency limits.
 
-    limits = await _acquire_concurrency_slots(names, occupy)
+    Args:
+        names: The names of the concurrency limits to acquire slots from.
+        occupy: The number of slots to acquire and hold from each limit.
+        timeout: The number of seconds to wait for the slots to be acquired before
+            raising a `TimeoutError`. A timeout of `None` will wait indefinitely.
+
+    Raises:
+        TimeoutError: If the slots are not acquired within the given timeout.
+
+    Example:
+    A simple example of using the async `concurrency` context manager:
+    ```python
+    from prefect.concurrency.asyncio import concurrency
+
+    async def resource_heavy():
+        async with concurrency("test", occupy=1):
+            print("Resource heavy task")
+
+    async def main():
+        await resource_heavy()
+    ```
+    """
+    names = names if isinstance(names, list) else [names]
+    async with timeout_async(seconds=timeout):
+        limits = await _acquire_concurrency_slots(names, occupy)
     acquisition_time = pendulum.now("UTC")
     emitted_events = _emit_concurrency_acquisition_events(limits, occupy)
 
-    async with timeout_async(seconds=timeout):
-        try:
-            yield
-        finally:
-            occupancy_period = cast(Interval, (pendulum.now("UTC") - acquisition_time))
-            await _release_concurrency_slots(
-                names, occupy, occupancy_period.total_seconds()
-            )
-            _emit_concurrency_release_events(limits, occupy, emitted_events)
+    try:
+        yield
+    finally:
+        occupancy_period = cast(Interval, (pendulum.now("UTC") - acquisition_time))
+        await _release_concurrency_slots(
+            names, occupy, occupancy_period.total_seconds()
+        )
+        _emit_concurrency_release_events(limits, occupy, emitted_events)
 
 
 async def rate_limit(names: Union[str, List[str]], occupy: int = 1):

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import time
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import (
     Any,
@@ -23,11 +23,6 @@ import pendulum
 from typing_extensions import ParamSpec
 
 from prefect import Task, get_client
-from prefect._internal.concurrency.cancellation import (
-    AlarmCancelScope,
-    AsyncCancelScope,
-    CancelledError,
-)
 from prefect.client.orchestration import SyncPrefectClient
 from prefect.client.schemas import TaskRun
 from prefect.client.schemas.objects import TaskRunResult
@@ -55,27 +50,10 @@ from prefect.utilities.engine import (
     collect_task_run_inputs,
     propose_state_sync,
 )
+from prefect.utilities.timeout import timeout, timeout_async
 
 P = ParamSpec("P")
 R = TypeVar("R")
-
-
-@asynccontextmanager
-async def timeout_async(seconds: Optional[float] = None):
-    try:
-        with AsyncCancelScope(timeout=seconds):
-            yield
-    except CancelledError:
-        raise TimeoutError(f"Task timed out after {seconds} second(s).")
-
-
-@contextmanager
-def timeout(seconds: Optional[float] = None):
-    try:
-        with AlarmCancelScope(timeout=seconds):
-            yield
-    except CancelledError:
-        raise TimeoutError(f"Task timed out after {seconds} second(s).")
 
 
 @dataclass

--- a/src/prefect/utilities/timeout.py
+++ b/src/prefect/utilities/timeout.py
@@ -1,0 +1,26 @@
+from contextlib import asynccontextmanager, contextmanager
+from typing import Optional
+
+from prefect._internal.concurrency.cancellation import (
+    AlarmCancelScope,
+    AsyncCancelScope,
+    CancelledError,
+)
+
+
+@asynccontextmanager
+async def timeout_async(seconds: Optional[float] = None):
+    try:
+        with AsyncCancelScope(timeout=seconds):
+            yield
+    except CancelledError:
+        raise TimeoutError(f"Scope timed out after {seconds} second(s).")
+
+
+@contextmanager
+def timeout(seconds: Optional[float] = None):
+    try:
+        with AlarmCancelScope(timeout=seconds):
+            yield
+    except CancelledError:
+        raise TimeoutError(f"Scope timed out after {seconds} second(s).")

--- a/tests/concurrency/test_concurrency_asyncio.py
+++ b/tests/concurrency/test_concurrency_asyncio.py
@@ -1,4 +1,7 @@
+import asyncio
 from unittest import mock
+
+import pytest
 
 from prefect import flow, task
 from prefect.concurrency.asyncio import (
@@ -167,6 +170,13 @@ async def test_concurrency_emits_events(
             "prefect.resource.id": f"prefect.concurrency-limit.{concurrency_limit.id}",
             "prefect.resource.role": "concurrency-limit",
         }
+
+
+@pytest.mark.usefixtures("concurrency_limit")
+async def test_concurrency_respects_timeout():
+    with pytest.raises(asyncio.TimeoutError, match=".*timed out after 0.1 second(s)*"):
+        async with concurrency("test", occupy=1, timeout=0.1):
+            await asyncio.sleep(1)
 
 
 async def test_rate_limit_orchestrates_api(

--- a/tests/concurrency/test_concurrency_sync.py
+++ b/tests/concurrency/test_concurrency_sync.py
@@ -1,4 +1,7 @@
+from time import sleep
 from unittest import mock
+
+import pytest
 
 from prefect import flow, task
 from prefect.concurrency.asyncio import (
@@ -162,6 +165,13 @@ async def test_concurrency_can_be_used_while_event_loop_is_running(
     resource_heavy()
 
     assert executed
+
+
+@pytest.mark.usefixtures("concurrency_limit")
+def test_concurrency_respects_timeout():
+    with pytest.raises(TimeoutError, match=".*timed out after 0.1 second(s)*."):
+        with concurrency("test", occupy=1, timeout=0.1):
+            sleep(0.2)
 
 
 def test_rate_limit_orchestrates_api(concurrency_limit_with_decay: ConcurrencyLimitV2):

--- a/tests/test_new_task_engine.py
+++ b/tests/test_new_task_engine.py
@@ -749,7 +749,7 @@ class TestTimeout:
         async def async_task():
             await asyncio.sleep(2)
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(TimeoutError, match=".*timed out after 0.1 second(s)*"):
             await run_task_async(async_task)
 
     async def test_timeout_sync_task(self):
@@ -757,5 +757,5 @@ class TestTimeout:
         def sync_task():
             time.sleep(2)
 
-        with pytest.raises(TimeoutError):
+        with pytest.raises(TimeoutError, match=".*timed out after 0.1 second(s)*"):
             run_task_sync(sync_task)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13262](https://togithub.com/PrefectHQ/prefect/pull/13262).



The original branch is upstream/gcl-timeout