### PR TITLE
Allow client-provided ID when creating a task run

### DIFF
--- a/src/prefect/client/orchestration.py
+++ b/src/prefect/client/orchestration.py
@@ -2169,6 +2169,7 @@ class PrefectClient:
         task: "TaskObject[P, R]",
         flow_run_id: Optional[UUID],
         dynamic_key: str,
+        id: Optional[UUID] = None,
         name: Optional[str] = None,
         extra_tags: Optional[Iterable[str]] = None,
         state: Optional[prefect.states.State[R]] = None,
@@ -2192,6 +2193,8 @@ class PrefectClient:
             task: The Task to run
             flow_run_id: The flow run id with which to associate the task run
             dynamic_key: A key unique to this particular run of a Task within the flow
+            id: An optional ID for the task run. If not provided, one will be generated
+                server-side.
             name: An optional name for the task run
             extra_tags: an optional list of extra tags to apply to the task run in
                 addition to `task.tags`
@@ -2208,6 +2211,7 @@ class PrefectClient:
             state = prefect.states.Pending()
 
         task_run_data = TaskRunCreate(
+            id=id,
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,
@@ -3810,6 +3814,7 @@ class SyncPrefectClient:
         task: "TaskObject[P, R]",
         flow_run_id: Optional[UUID],
         dynamic_key: str,
+        id: Optional[UUID] = None,
         name: Optional[str] = None,
         extra_tags: Optional[Iterable[str]] = None,
         state: Optional[prefect.states.State[R]] = None,
@@ -3833,6 +3838,8 @@ class SyncPrefectClient:
             task: The Task to run
             flow_run_id: The flow run id with which to associate the task run
             dynamic_key: A key unique to this particular run of a Task within the flow
+            id: An optional ID for the task run. If not provided, one will be generated
+                server-side.
             name: An optional name for the task run
             extra_tags: an optional list of extra tags to apply to the task run in
                 addition to `task.tags`
@@ -3849,6 +3856,7 @@ class SyncPrefectClient:
             state = prefect.states.Pending()
 
         task_run_data = TaskRunCreate(
+            id=id,
             name=name,
             flow_run_id=flow_run_id,
             task_key=task.task_key,

--- a/src/prefect/client/schemas/actions.py
+++ b/src/prefect/client/schemas/actions.py
@@ -302,6 +302,7 @@ class FlowRunUpdate(ActionBaseModel):
 class TaskRunCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a task run"""
 
+    id: Optional[UUID] = Field(None, description="The ID to assign to the task run")
     # TaskRunCreate states must be provided as StateCreate objects
     state: Optional[StateCreate] = Field(
         default=None, description="The state of the task run to create"

--- a/src/prefect/new_task_engine.py
+++ b/src/prefect/new_task_engine.py
@@ -17,6 +17,7 @@ from typing import (
     Union,
     cast,
 )
+from uuid import UUID
 
 import pendulum
 from typing_extensions import ParamSpec
@@ -275,7 +276,9 @@ class TaskRunEngine(Generic[P, R]):
                 self.logger = current_logger
 
     @contextmanager
-    def start(self) -> Generator["TaskRunEngine", Any, Any]:
+    def start(
+        self, task_run_id: Optional[UUID] = None
+    ) -> Generator["TaskRunEngine", Any, Any]:
         """
         Enters a client context and creates a task run if needed.
         """
@@ -286,6 +289,7 @@ class TaskRunEngine(Generic[P, R]):
                 if not self.task_run:
                     self.task_run = run_sync(
                         self.task.create_run(
+                            id=task_run_id,
                             client=client,
                             parameters=self.parameters,
                             flow_run_context=FlowRunContext.get(),
@@ -324,15 +328,20 @@ class TaskRunEngine(Generic[P, R]):
 
 def run_task_sync(
     task: Task[P, R],
+    task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
     return_type: Literal["state", "result"] = "result",
 ) -> Union[R, State, None]:
-    engine = TaskRunEngine[P, R](task=task, parameters=parameters, task_run=task_run)
+    engine = TaskRunEngine[P, R](
+        task=task,
+        parameters=parameters,
+        task_run=task_run,
+    )
 
     # This is a context manager that keeps track of the run of the task run.
-    with engine.start() as run:
+    with engine.start(task_run_id=task_run_id) as run:
         run.begin_run()
 
         while run.is_running():
@@ -362,6 +371,7 @@ def run_task_sync(
 
 async def run_task_async(
     task: Task[P, Coroutine[Any, Any, R]],
+    task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
@@ -375,7 +385,7 @@ async def run_task_async(
     engine = TaskRunEngine[P, R](task=task, parameters=parameters, task_run=task_run)
 
     # This is a context manager that keeps track of the run of the task run.
-    with engine.start() as run:
+    with engine.start(task_run_id=task_run_id) as run:
         run.begin_run()
 
         while run.is_running():
@@ -405,6 +415,7 @@ async def run_task_async(
 
 def run_task(
     task: Task[P, R],
+    task_run_id: Optional[UUID] = None,
     task_run: Optional[TaskRun] = None,
     parameters: Optional[Dict[str, Any]] = None,
     wait_for: Optional[Iterable[PrefectFuture[A, Async]]] = None,
@@ -412,6 +423,7 @@ def run_task(
 ) -> Union[R, State, None]:
     kwargs = dict(
         task=task,
+        task_run_id=task_run_id,
         task_run=task_run,
         parameters=parameters,
         wait_for=wait_for,

--- a/src/prefect/server/api/task_runs.py
+++ b/src/prefect/server/api/task_runs.py
@@ -57,7 +57,10 @@ async def create_task_run(
     If no state is provided, the task run will be created in a PENDING state.
     """
     # hydrate the input model into a full task run / state model
-    task_run = schemas.core.TaskRun(**task_run.dict())
+    task_run_dict = task_run.dict()
+    if not task_run_dict.get("id"):
+        task_run_dict.pop("id", None)
+    task_run = schemas.core.TaskRun(**task_run_dict)
 
     if not task_run.state:
         task_run.state = schemas.states.Pending()

--- a/src/prefect/server/schemas/actions.py
+++ b/src/prefect/server/schemas/actions.py
@@ -421,6 +421,10 @@ class StateCreate(ActionBaseModel):
 class TaskRunCreate(ActionBaseModel):
     """Data used by the Prefect REST API to create a task run"""
 
+    id: Optional[UUID] = Field(
+        default=None,
+        description="The ID to assign to the task run. If not provided, a random UUID will be generated.",
+    )
     # TaskRunCreate states must be provided as StateCreate objects
     state: Optional[StateCreate] = Field(
         default=None, description="The state of the task run to create"

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -27,7 +27,7 @@ from typing import (
     cast,
     overload,
 )
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from typing_extensions import Literal, ParamSpec
 
@@ -518,8 +518,9 @@ class Task(Generic[P, R]):
 
     async def create_run(
         self,
-        client: Optional[Union[PrefectClient, SyncPrefectClient]],
-        parameters: Dict[str, Any] = None,
+        client: Union[PrefectClient, SyncPrefectClient],
+        id: Optional[UUID] = None,
+        parameters: Optional[Dict[str, Any]] = None,
         flow_run_context: Optional[FlowRunContext] = None,
         parent_task_run_context: Optional[TaskRunContext] = None,
         wait_for: Optional[Iterable[PrefectFuture]] = None,
@@ -591,6 +592,7 @@ class Task(Generic[P, R]):
                 else None
             ),
             dynamic_key=str(dynamic_key),
+            id=id,
             state=Pending(),
             task_inputs=task_inputs,
             extra_tags=TagsContext.get().current_tags,


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13276](https://togithub.com/PrefectHQ/prefect/pull/13276).



The original branch is upstream/client-side-task-run-ids