### PR TITLE
Set `testpaths` for `pytest` to avoid default conftest conflict

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [tool:pytest]
+testpaths = tests
 addopts = -rfEs
 norecursedirs = *.egg-info .git .mypy_cache node_modules .pytest_cache .vscode
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13368](https://togithub.com/PrefectHQ/prefect/pull/13368).



The original branch is upstream/set-testpaths