### PR TITLE
Bump @prefecthq/prefect-ui-library from 2.10.4 to 3.0.3 in /ui

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.8.0",
       "dependencies": {
         "@prefecthq/prefect-design": "2.10.5",
-        "@prefecthq/prefect-ui-library": "2.10.4",
+        "@prefecthq/prefect-ui-library": "3.0.3",
         "@prefecthq/vue-charts": "2.0.3",
         "@prefecthq/vue-compositions": "1.11.4",
         "@types/lodash.debounce": "4.0.9",
@@ -913,9 +913,9 @@
       }
     },
     "node_modules/@prefecthq/prefect-ui-library": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.10.4.tgz",
-      "integrity": "sha512-Q46+YTiKzmypyg3VUk+0dOfX/lATaLPlBP293G7iug+nnaDvb/yuDNlDE/xh08E14CeVn+8f7hwt/k0NvY+f2w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-3.0.3.tgz",
+      "integrity": "sha512-JfkU9XVqH6cP8lmle1mBneNmw+svw4RTvpFjPb05IE/ccsO+EQjEKppLXIBsE9CxWaSOYuyMfUz8WNh0KJ24SA==",
       "dependencies": {
         "@prefecthq/graphs": "2.2.15",
         "axios": "1.6.7",
@@ -7392,9 +7392,9 @@
       }
     },
     "@prefecthq/prefect-ui-library": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-2.10.4.tgz",
-      "integrity": "sha512-Q46+YTiKzmypyg3VUk+0dOfX/lATaLPlBP293G7iug+nnaDvb/yuDNlDE/xh08E14CeVn+8f7hwt/k0NvY+f2w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@prefecthq/prefect-ui-library/-/prefect-ui-library-3.0.3.tgz",
+      "integrity": "sha512-JfkU9XVqH6cP8lmle1mBneNmw+svw4RTvpFjPb05IE/ccsO+EQjEKppLXIBsE9CxWaSOYuyMfUz8WNh0KJ24SA==",
       "requires": {
         "@prefecthq/graphs": "2.2.15",
         "axios": "1.6.7",

--- a/ui/package.json
+++ b/ui/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@prefecthq/prefect-design": "2.10.5",
-    "@prefecthq/prefect-ui-library": "2.10.4",
+    "@prefecthq/prefect-ui-library": "3.0.3",
     "@prefecthq/vue-charts": "2.0.3",
     "@prefecthq/vue-compositions": "1.11.4",
     "@types/lodash.debounce": "4.0.9",


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13461](https://togithub.com/PrefectHQ/prefect/pull/13461).



The original branch is upstream/dependabot/npm_and_yarn/ui/prefecthq/prefect-ui-library-3.0.3