### PR TITLE
add `not_any_` filters to flow run state name/type

### DIFF
--- a/src/prefect/client/schemas/filters.py
+++ b/src/prefect/client/schemas/filters.py
@@ -166,11 +166,17 @@ class FlowRunFilterStateType(PrefectBaseModel):
     any_: Optional[List[StateType]] = Field(
         default=None, description="A list of flow run state types to include"
     )
+    not_any_: Optional[List[StateType]] = Field(
+        default=None, description="A list of flow run state types to exclude"
+    )
 
 
 class FlowRunFilterStateName(PrefectBaseModel):
     any_: Optional[List[str]] = Field(
         default=None, description="A list of flow run state names to include"
+    )
+    not_any_: Optional[List[str]] = Field(
+        default=None, description="A list of flow run state names to exclude"
     )
 
 

--- a/src/prefect/server/schemas/filters.py
+++ b/src/prefect/server/schemas/filters.py
@@ -329,11 +329,16 @@ class FlowRunFilterStateType(PrefectFilterBaseModel):
     any_: Optional[List[schemas.states.StateType]] = Field(
         default=None, description="A list of flow run state types to include"
     )
+    not_any_: Optional[List[schemas.states.StateType]] = Field(
+        default=None, description="A list of flow run state types to exclude"
+    )
 
     def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
             filters.append(orm_models.FlowRun.state_type.in_(self.any_))
+        if self.not_any_ is not None:
+            filters.append(orm_models.FlowRun.state_type.not_in(self.not_any_))
         return filters
 
 
@@ -343,11 +348,16 @@ class FlowRunFilterStateName(PrefectFilterBaseModel):
     any_: Optional[List[str]] = Field(
         default=None, description="A list of flow run state names to include"
     )
+    not_any_: Optional[List[str]] = Field(
+        default=None, description="A list of flow run state names to exclude"
+    )
 
     def _get_filter_list(self) -> List:
         filters = []
         if self.any_ is not None:
             filters.append(orm_models.FlowRun.state_name.in_(self.any_))
+        if self.not_any_ is not None:
+            filters.append(orm_models.FlowRun.state_name.not_in(self.not_any_))
         return filters
 
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13920](https://togithub.com/PrefectHQ/prefect/pull/13920).



The original branch is upstream/exclude-state-flow-run-filter