### PR TITLE
Remove stray warning about tasks that weren't originally `SCHEDULED`

### DIFF
--- a/src/prefect/server/services/task_scheduling.py
+++ b/src/prefect/server/services/task_scheduling.py
@@ -99,9 +99,8 @@ class TaskSchedulingTimeouts(LoopService):
                 if prior_scheduled_state.type == states.StateType.SCHEDULED:
                     break
             else:
-                self.logger.warning(
-                    "No prior scheduled state found for task run %s", task_run.id
-                )
+                # This wasn't originally a SCHEDULED background task, so we won't
+                # attempt to reschedule it.
                 continue
 
             rescheduled = states.Scheduled(


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13925](https://togithub.com/PrefectHQ/prefect/pull/13925).



The original branch is upstream/remove-stray-task-scheduling-warning