### PR TITLE
Use RC version of `prefect-kubernetes` for Docker image builds

### DIFF
--- a/.github/workflows/docker-images.yaml
+++ b/.github/workflows/docker-images.yaml
@@ -111,7 +111,7 @@ jobs:
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             ${{ ( endsWith(matrix.flavor, 'conda') && 'BASE_IMAGE=prefect-conda' ) || '' }}
-            ${{ ( endsWith(matrix.flavor, 'kubernetes') && 'EXTRA_PIP_PACKAGES=prefect-kubernetes' ) || '' }}
+            ${{ ( endsWith(matrix.flavor, 'kubernetes') && 'EXTRA_PIP_PACKAGES=prefect-kubernetes>=0.4.0rc1' ) || '' }}
           tags: ${{ join(steps.metadata-dev.outputs.tags) }},${{ join(steps.metadata-prod.outputs.tags) }}
           labels: ${{ steps.metadata-dev.outputs.labels }}
           push: true


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13932](https://togithub.com/PrefectHQ/prefect/pull/13932).



The original branch is upstream/fix-docker-builds