### PR TITLE
Raise a more useful error when trying to stream with no `PREFECT_API_URL`

### DIFF
--- a/src/prefect/events/clients.py
+++ b/src/prefect/events/clients.py
@@ -63,6 +63,12 @@ def get_events_subscriber(
     reconnection_attempts: int = 10,
 ) -> "PrefectEventSubscriber":
     api_url = PREFECT_API_URL.value()
+    if not api_url:
+        raise ValueError(
+            "A Prefect server or Prefect Cloud is required to start an event "
+            "subscriber.  Please check the PREFECT_API_URL setting in your profile."
+        )
+
     if isinstance(api_url, str) and api_url.startswith(PREFECT_CLOUD_API_URL.value()):
         return PrefectCloudEventSubscriber(
             filter=filter, reconnection_attempts=reconnection_attempts


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13939](https://togithub.com/PrefectHQ/prefect/pull/13939).



The original branch is upstream/better-error-stream-no-api-url