### PR TITLE
Fix `ThreadPoolTaskRunner` concurrency by copying `max_workers` on duplication

### DIFF
--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -208,7 +208,7 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture]):
         self._max_workers = max_workers
 
     def duplicate(self) -> "ThreadPoolTaskRunner":
-        return type(self)()
+        return type(self)(max_workers=self._max_workers)
 
     def submit(
         self,
@@ -287,6 +287,11 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture]):
             self._executor.shutdown()
             self._executor = None
         super().__exit__(exc_type, exc_value, traceback)
+
+    def __eq__(self, value: object) -> bool:
+        if not isinstance(value, ThreadPoolTaskRunner):
+            return False
+        return self._max_workers == value._max_workers
 
 
 # Here, we alias ConcurrentTaskRunner to ThreadPoolTaskRunner for backwards compatibility

--- a/tests/test_task_runners.py
+++ b/tests/test_task_runners.py
@@ -60,10 +60,11 @@ class MockFuture(PrefectWrappedFuture):
 
 class TestThreadPoolTaskRunner:
     def test_duplicate(self):
-        runner = ThreadPoolTaskRunner()
+        runner = ThreadPoolTaskRunner(max_workers=100)
         duplicate_runner = runner.duplicate()
         assert isinstance(duplicate_runner, ThreadPoolTaskRunner)
         assert duplicate_runner is not runner
+        assert duplicate_runner == runner
 
     def test_runner_must_be_started(self):
         runner = ThreadPoolTaskRunner()


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13943](https://togithub.com/PrefectHQ/prefect/pull/13943).



The original branch is upstream/fix-thread-pool-tr-concurrency