### PR TITLE
Update uvicorn requirement from <0.29.0,>=0.14.0 to >=0.14.0,<0.31.0

### DIFF
--- a/requirements-client.txt
+++ b/requirements-client.txt
@@ -33,5 +33,5 @@ sniffio >=1.3.0, < 2.0.0
 toml >= 0.10.0
 typing_extensions >= 4.5.0, < 5.0.0
 ujson >= 5.8.0, < 6.0.0
-uvicorn >= 0.14.0, < 0.29.0
+uvicorn >= 0.14.0, < 0.31.0
 websockets >= 10.4, < 13.0


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13610](https://togithub.com/PrefectHQ/prefect/pull/13610).



The original branch is upstream/dependabot/pip/uvicorn-gte-0.14.0-and-lt-0.31.0