### PR TITLE
change the  default settings of PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS  to 1 (equals to the Cloud does)

### DIFF
--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -777,7 +777,7 @@ This value sets the default retry delay seconds for all tasks.
 This value does not overwrite individually set retry delay seconds
 """
 
-PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS = Setting(int, default=30)
+PREFECT_TASK_RUN_TAG_CONCURRENCY_SLOT_WAIT_SECONDS = Setting(int, default=1)
 """
 The number of seconds to wait before retrying when a task run
 cannot secure a concurrency slot from the server.


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#13658](https://togithub.com/PrefectHQ/prefect/pull/13658).



The original branch is fork-13658-fjteam/main