### PR TITLE
Bump `TaskRunWaiter` cache size and expiration time and pin task worker thread pool workers to passed `limit`

### DIFF
--- a/src/prefect/task_runs.py
+++ b/src/prefect/task_runs.py
@@ -71,7 +71,7 @@ class TaskRunWaiter:
         self.logger = get_logger("TaskRunWaiter")
         self._consumer_task: Optional[asyncio.Task] = None
         self._observed_completed_task_runs: TTLCache[uuid.UUID, bool] = TTLCache(
-            maxsize=100, ttl=60
+            maxsize=10000, ttl=600
         )
         self._completion_events: Dict[uuid.UUID, asyncio.Event] = {}
         self._loop: Optional[asyncio.AbstractEventLoop] = None

--- a/src/prefect/task_worker.py
+++ b/src/prefect/task_worker.py
@@ -86,7 +86,7 @@ class TaskWorker:
             )
 
         self._runs_task_group: anyio.abc.TaskGroup = anyio.create_task_group()
-        self._executor = ThreadPoolExecutor()
+        self._executor = ThreadPoolExecutor(max_workers=limit if limit else None)
         self._limiter = anyio.CapacityLimiter(limit) if limit else None
 
     @property


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14030](https://togithub.com/PrefectHQ/prefect/pull/14030).



The original branch is upstream/bump-task-run-waiter-cache