### PR TITLE
Disables server-side `PENDING` task rescheduling by default

### DIFF
--- a/src/prefect/server/services/task_scheduling.py
+++ b/src/prefect/server/services/task_scheduling.py
@@ -35,6 +35,9 @@ class TaskSchedulingTimeouts(LoopService):
         """
         Periodically reschedules pending task runs that have been pending for too long.
         """
+        if not PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT:
+            return
+
         async with db.session_context(begin_transaction=True) as session:
             if self._first_run:
                 await self.restore_scheduled_tasks_if_necessary(session)

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1541,7 +1541,7 @@ The maximum number of retries to queue for submission.
 
 PREFECT_TASK_SCHEDULING_PENDING_TASK_TIMEOUT = Setting(
     timedelta,
-    default=timedelta(seconds=30),
+    default=timedelta(0),
 )
 """
 How long before a PENDING task are made available to another task worker.  In practice,


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14128](https://togithub.com/PrefectHQ/prefect/pull/14128).



The original branch is upstream/disable-pending-task-rescheduling-by-default