### PR TITLE
Add debug prints to determine why latest tag can't be determined

### DIFF
--- a/.github/workflows/nightly-release.yaml
+++ b/.github/workflows/nightly-release.yaml
@@ -14,15 +14,22 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
-        persist-credentials: false
         fetch-depth: 0
+
+    - name: Print all tags for debugging
+      run: |
+        git tag -l
 
     - name: Get latest tag
       id: get_latest_tag
       run: |
         latest_tag=$(git tag -l | grep -E '^(3\.\d+\.\d+(?:[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?)$' | sort -V | tail -n 1)
+        echo "Fetched tags:"
+        git tag -l
+        echo "Filtered tags:"
+        git tag -l | grep -E '^(3\.\d+\.\d+(?:[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?)$'
         if [ -z "$latest_tag" ]; then
           echo "No matching tags found."
           exit 1


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14137](https://togithub.com/PrefectHQ/prefect/pull/14137).



The original branch is upstream/fix-nightly-release-workflow-2