### PR TITLE
Remove references to `ConcurrentTaskRunner` from docs and ensure examples use `.wait()`

### DIFF
--- a/docs/2.19.x/concepts/task-runners.mdx
+++ b/docs/2.19.x/concepts/task-runners.mdx
@@ -1,5 +1,5 @@
 ---
-title: task Runners
+title: Task Runners
 description: Task runners enable you to engage specific executors for Prefect tasks, such as for concurrent, parallel, or distributed execution of tasks.
 ---
 

--- a/docs/3.0rc/develop/write-flows/index.mdx
+++ b/docs/3.0rc/develop/write-flows/index.mdx
@@ -387,7 +387,7 @@ Flows allow a great deal of configuration by passing arguments to the decorator.
 | `retries`                                          | An optional number of times to retry on flow run failure.                                                                                                                                                            |
 | <span class="no-wrap">`retry_delay_seconds`</span> | An optional number of seconds to wait before retrying the flow after failure. This is only applicable if `retries` is nonzero.                                                                                       |
 | `flow_run_name`                                    | An optional name to distinguish runs of this flow; this name can be provided as a string template with the flow's parameters as variables; you can also provide this name as a function that returns a string.       |
-| `task_runner`                                      | An optional [task runner](/3.0rc/develop/write-tasks/use-task-runners/) to use for task execution within the flow when you `.submit()` tasks. If not provided and you `.submit()` tasks, the `ConcurrentTaskRunner` is used.         |
+| `task_runner`                                      | An optional [task runner](/3.0rc/develop/write-tasks/use-task-runners/) to use for task execution within the flow when you `.submit()` tasks. If not provided and you `.submit()` tasks, the `ThreadPoolTaskRunner` is used.         |
 | `timeout_seconds`                                  | An optional number of seconds indicating a maximum runtime for the flow. If the flow exceeds this runtime, it is marked as failed. Flow execution may continue until the next task is called.                   |
 | `validate_parameters`                              | Boolean indicating whether parameters passed to flows are validated by Pydantic. Default is `True`.                                                                                                                  |
 | `version`                                          | An optional version string for the flow. If not provided, we will attempt to create a version string as a hash of the file containing the wrapped function. If the file cannot be located, the version will be null. |
@@ -578,7 +578,6 @@ Running the `hello_world()` flow (in this example from the file `hello.py`) crea
 ```bash
 $ python hello.py
 15:19:21.651 | INFO    | prefect.engine - Created flow run 'daft-cougar' for flow 'Hello Flow'
-15:19:21.651 | INFO    | Flow run 'daft-cougar' - Using task runner 'ConcurrentTaskRunner'
 15:19:21.945 | INFO    | Flow run 'daft-cougar' - Created task run 'Print Hello-84f0fe0e-0' for task 'Print Hello'
 Hello Marvin!
 15:19:22.055 | INFO    | Task run 'Print Hello-84f0fe0e-0' - Finished in state Completed()
@@ -719,7 +718,6 @@ Running this flow produces the following result:
 <div class="terminal">
 ```bash
 22:22:36.864 | INFO    | prefect.engine - Created flow run 'acrid-tuatara' for flow 'always-fails-flow'
-22:22:36.864 | INFO    | Flow run 'acrid-tuatara' - Starting 'ConcurrentTaskRunner'; submitted tasks will be run concurrently...
 22:22:37.060 | ERROR   | Flow run 'acrid-tuatara' - Encountered exception during execution:
 Traceback (most recent call last):...
 ValueError: This flow immediately fails
@@ -756,7 +754,6 @@ Running this flow produces the following result:
 <div class="terminal">
 ```bash
 18:32:05.345 | INFO    | prefect.engine - Created flow run 'auburn-lionfish' for flow 'always-fails-flow'
-18:32:05.346 | INFO    | Flow run 'auburn-lionfish' - Starting 'ConcurrentTaskRunner'; submitted tasks will be run concurrently...
 18:32:05.582 | INFO    | Flow run 'auburn-lionfish' - Created task run 'always_fails_task-96e4be14-0' for task 'always_fails_task'
 18:32:05.582 | INFO    | Flow run 'auburn-lionfish' - Submitted task run 'always_fails_task-96e4be14-0' for execution.
 18:32:05.610 | ERROR   | Task run 'always_fails_task-96e4be14-0' - Encountered exception during execution:
@@ -806,7 +803,6 @@ Running this flow produces the following result&mdash;it succeeds because it ret
 <div class="terminal">
 ```bash
 18:35:24.965 | INFO    | prefect.engine - Created flow run 'whispering-guan' for flow 'always-succeeds-flow'
-18:35:24.965 | INFO    | Flow run 'whispering-guan' - Starting 'ConcurrentTaskRunner'; submitted tasks will be run concurrently...
 18:35:25.204 | INFO    | Flow run 'whispering-guan' - Created task run 'always_fails_task-96e4be14-0' for task 'always_fails_task'
 18:35:25.205 | INFO    | Flow run 'whispering-guan' - Submitted task run 'always_fails_task-96e4be14-0' for execution.
 18:35:25.232 | ERROR   | Task run 'always_fails_task-96e4be14-0' - Encountered exception during execution:
@@ -857,7 +853,6 @@ Note that the final state is `Failed`, but the states of each of the returned fu
 <div class="terminal">
 ```bash
 20:57:51.547 | INFO    | prefect.engine - Created flow run 'impartial-gorilla' for flow 'always-fails-flow'
-20:57:51.548 | INFO    | Flow run 'impartial-gorilla' - Using task runner 'ConcurrentTaskRunner'
 20:57:51.645 | INFO    | Flow run 'impartial-gorilla' - Created task run 'always_fails_task-58ea43a6-0' for task 'always_fails_task'
 20:57:51.686 | INFO    | Flow run 'impartial-gorilla' - Created task run 'always_succeeds_task-c9014725-0' for task 'always_succeeds_task'
 20:57:51.727 | ERROR   | Task run 'always_fails_task-58ea43a6-0' - Encountered exception during execution:
@@ -913,7 +908,6 @@ Running this flow produces the following result.
 <div class="terminal">
 ```bash
 18:37:42.844 | INFO    | prefect.engine - Created flow run 'lavender-elk' for flow 'always-succeeds-flow'
-18:37:42.845 | INFO    | Flow run 'lavender-elk' - Starting 'ConcurrentTaskRunner'; submitted tasks will be run concurrently...
 18:37:43.125 | INFO    | Flow run 'lavender-elk' - Created task run 'always_fails_task-96e4be14-0' for task 'always_fails_task'
 18:37:43.126 | INFO    | Flow run 'lavender-elk' - Submitted task run 'always_fails_task-96e4be14-0' for execution.
 18:37:43.162 | INFO    | Flow run 'lavender-elk' - Created task run 'always_succeeds_task-9c27db32-0' for task 'always_succeeds_task'
@@ -954,7 +948,6 @@ Running this flow produces the following result.
 <div class="terminal">
 ```bash
 21:02:45.715 | INFO    | prefect.engine - Created flow run 'sparkling-pony' for flow 'always-succeeds-flow'
-21:02:45.715 | INFO    | Flow run 'sparkling-pony' - Using task runner 'ConcurrentTaskRunner'
 21:02:45.816 | INFO    | Flow run 'sparkling-pony' - Created task run 'always_fails_task-58ea43a6-0' for task 'always_fails_task'
 21:02:45.853 | ERROR   | Task run 'always_fails_task-58ea43a6-0' - Encountered exception during execution:
 Traceback (most recent call last):...

--- a/docs/3.0rc/develop/write-tasks/dask-and-ray.mdx
+++ b/docs/3.0rc/develop/write-tasks/dask-and-ray.mdx
@@ -439,7 +439,7 @@ Many workflows include a variety of tasks, and not all of them benefit from para
 Because task runners are specified on flows, you can assign different task runners to tasks by using
 [subflows](/3.0rc/develop/write-flows/#composing-flows) to organize those tasks.
 
-This example uses the default `ConcurrentTaskRunner`. Then you call a `ray_greetings()` subflow that
+This example uses the default `ThreadPoolTaskRunner`. Then you call a `ray_greetings()` subflow that
 uses the `RayTaskRunner` to execute the same tasks in a Ray instance.
 
 ```python

--- a/docs/3.0rc/develop/write-tasks/separate-logic.mdx
+++ b/docs/3.0rc/develop/write-tasks/separate-logic.mdx
@@ -26,7 +26,6 @@ When you run this flow, you see output like the following:
 ```bash
 $ python hello.py
 15:11:23.594 | INFO    | prefect.engine - Created flow run 'benevolent-donkey' for flow 'hello-world'
-15:11:23.594 | INFO    | Flow run 'benevolent-donkey' - Using task runner 'ConcurrentTaskRunner'
 Hello Marvin!
 15:11:24.447 | INFO    | Flow run 'benevolent-donkey' - Finished in state Completed()
 ```
@@ -58,7 +57,6 @@ When you run this flow, you see the following output, which illustrates how the 
 ```bash
 $ python hello.py
 15:15:58.673 | INFO    | prefect.engine - Created flow run 'loose-wolverine' for flow 'Hello Flow'
-15:15:58.674 | INFO    | Flow run 'loose-wolverine' - Using task runner 'ConcurrentTaskRunner'
 15:15:58.973 | INFO    | Flow run 'loose-wolverine' - Created task run 'Print Hello-84f0fe0e-0' for task 'Print Hello'
 Hello Marvin!
 15:15:59.037 | INFO    | Task run 'Print Hello-84f0fe0e-0' - Finished in state Completed()

--- a/docs/3.0rc/develop/write-tasks/upstream-dependencies.mdx
+++ b/docs/3.0rc/develop/write-tasks/upstream-dependencies.mdx
@@ -18,18 +18,18 @@ Only results from tasks inform Prefect's ability to determine dependencies. Retu
 without task decorators, including subflows, do not carry the same information about their origin as task results.
 </Note>
 
-When using non-sequential task runners such as the [`ConcurrentTaskRunner`](/3.0rc/api-ref/prefect/task-runners/#prefect.task_runners.ConcurrentTaskRunner) or 
+When using non-sequential task runners such as the [`ThreadPoolTaskRunner`](/3.0rc/api-ref/prefect/task-runners/#prefect.task_runners.ThreadPoolTaskRunner) or 
 [`DaskTaskRunner`](https://prefecthq.github.io/prefect-dask/), the order of execution for submitted 
 tasks is not guaranteed unless you specify their dependencies.
 
-For example, compare how tasks submitted to the `ConcurrentTaskRunner` behave with and without 
+For example, compare how tasks submitted to the `ThreadPoolTaskRunner` behave with and without 
 upstream dependencies:
 
 <Tabs>
     <Tab title="Without dependencies">
 
     ```python
-    @flow(log_prints=True) # Default task runner is ConcurrentTaskRunner
+    @flow(log_prints=True) # Default task runner is ThreadPoolTaskRunner
     def flow_of_tasks():
         # no dependencies, execution is order not guaranteed
         first.submit()
@@ -68,7 +68,7 @@ upstream dependencies:
     <Tab title="With dependencies">
 
     ```python
-    @flow(log_prints=True) # Default task runner is ConcurrentTaskRunner
+    @flow(log_prints=True) # Default task runner is ThreadPoolTaskRunner
     def flow_of_tasks():
         # with dependencies, tasks execute in order
         first_result = first.submit()

--- a/docs/3.0rc/develop/write-tasks/use-task-runners.mdx
+++ b/docs/3.0rc/develop/write-tasks/use-task-runners.mdx
@@ -16,27 +16,26 @@ enables you to run tasks concurrently, or in parallel using a distributed execut
 ### Submitting tasks
 
 Using the `.submit()` method to submit a task also causes the task run to return a 
-[`PrefectFuture`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectFuture), which is an 
+[`PrefectConcurrentFuture`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectConcurrentFuture), which is an 
 Prefect object that contains both any _data_ returned by the task function; and a 
 [`State`](/3.0rc/api-ref/server/schemas/states/), which is a Prefect object indicating the state of the task run.
 
-Using `.submit()` without specifying a task runner will run your tasks concurrently by default.
+Using `.submit()` without specifying a task runner will run your tasks in a threadpool by default.
 
 
 ### Built-in task runners and integrations
 
-Prefect provides the following built-in task runner: 
+Prefect uses a `ThreadPoolTaskRunner` by default: 
 
-- [`ConcurrentTaskRunner`](/3.0rc/api-ref/prefect/task-runners/#prefect.task_runners.ConcurrentTaskRunner) 
-can run tasks concurrently, allowing tasks to switch when blocking on IO. 
-Tasks are submitted to a thread pool maintained by `anyio`.
+- [`ThreadPoolTaskRunner`](/3.0rc/api-ref/prefect/task-runners/#prefect.task_runners.ThreadPoolTaskRunner) 
+can run tasks concurrently. Tasks are submitted to a thread pool for execution.
 
 The following Prefect-developed task runners for parallel or distributed task 
 execution are available as [integrations](/integrations/catalog/):
 
-- [`DaskTaskRunner`](https://prefecthq.github.io/prefect-dask/) can run tasks requiring 
-parallel execution using [`dask.distributed`](http://distributed.dask.org/). 
-- [`RayTaskRunner`](https://prefecthq.github.io/prefect-ray/) can run tasks requiring 
+- [`DaskTaskRunner`](https://github.com/PrefectHQ/prefect/tree/main/src/integrations/prefect-dask) can run tasks requiring 
+parallel execution using [`dask.distributed`](http://distributed.dask.org/).
+- [`RayTaskRunner`](https://github.com/PrefectHQ/prefect/tree/main/src/integrations/prefect-ray) can run tasks requiring 
 parallel execution using [Ray](https://www.ray.io/).
 
 <Note>
@@ -65,35 +64,11 @@ Calling the task directly, without `.submit()`, from within a flow runs the task
 instead of using a specified task runner.
 </Note>
 
-For example, you can use `ConcurrentTaskRunner` to allow tasks to switch when they would block.
-
-```python hl_lines="2 11"
-from prefect import flow, task
-from prefect.task_runners import ConcurrentTaskRunner
-import time
-
-@task
-def stop_at_floor(floor):
-    print(f"elevator moving to floor {floor}")
-    time.sleep(floor)
-    print(f"elevator stops on floor {floor}")
-
-@flow(task_runner=ConcurrentTaskRunner())
-def elevator():
-    for floor in range(10, 0, -1):
-        stop_at_floor.submit(floor)
-```
-
 If you specify an uninitialized task runner class, a task runner instance of that type 
 is created with the default settings. You can also pass additional configuration parameters 
 for task runners that accept parameters, such as [`DaskTaskRunner`](https://prefecthq.github.io/prefect-dask/) 
 and [`RayTaskRunner`](https://prefecthq.github.io/prefect-ray/).
 
-<Tip>
-**Default task runner**
-If you don't specify a task runner for a flow and you call a task with `.submit()` within the flow, 
-Prefect uses the default `ConcurrentTaskRunner`.
-</Tip>
 ## Running tasks sequentially
 
 Sometimes, it's useful to force tasks to run sequentially to make it easier to reason about the 
@@ -131,12 +106,12 @@ using a specific task runner. In this case, you can create [subflows](/3.0rc/dev
 for tasks that need to use a different task runner.
 
 For example, you can have a flow (in the example below called `multiple_runner_flow`) that runs its tasks locally 
-using the `ConcurrentTaskRunner`. If you have some tasks that can run more efficiently in parallel on a Dask cluster, 
+using the default `ThreadPoolTaskRunner`. If you have some tasks that can run more efficiently in parallel on a Dask cluster, 
 you can create a subflow (such as `dask_subflow`) to run those tasks using the `DaskTaskRunner`.
 
 ```python
 from prefect import flow, task
-from prefect.task_runners import ConcurrentTaskRunner
+from prefect.task_runners import ThreadPoolTaskRunner
 from prefect_dask.task_runners import DaskTaskRunner
 import time
 
@@ -145,10 +120,10 @@ def hello_local():
     time.sleep(2)
     print("Hello!")
 
-@flow(task_runner=ConcurrentTaskRunner())
+@flow(task_runner=ThreadPoolTaskRunner())
 def concurrent_subflow():
-    hello_local.submit()
-    hello_local.submit()
+    hello_future = hello_local.submit()
+    hello_future.wait()
 
 @task
 def hello_dask():
@@ -156,9 +131,10 @@ def hello_dask():
 
 @flow(task_runner=DaskTaskRunner())
 def dask_subflow():
-    hello_dask.submit()
+    hello_future = hello_dask.submit()
+    hello_future.wait()
 
-@flow(task_runner=ConcurrentTaskRunner())
+@flow()
 def parent_flow():
     concurrent_subflow()
     dask_subflow()
@@ -174,10 +150,10 @@ You should guard the `main` function by using `if __name__ == "__main__"` to avo
 ## Use results from submitted tasks
 
 When you use `.submit()` to submit a task to a task runner, the task runner creates a 
-[`PrefectFuture`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectFuture) for access to the state and 
+[`PrefectConcurrentFuture`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectConcurrentFuture) for access to the state and 
 result of the task.
 
-A `PrefectFuture` is an object that provides access to a computation happening in a task runner, 
+A `PrefectConcurrentFuture` is an object that provides access to a computation happening in a task runner, 
 even if that computation happens on a remote system.
 
 The following example saves the return value of calling `.submit()` on the task `say_hello` to 
@@ -194,22 +170,23 @@ def say_hello(name):
 def hello_world():
     future = say_hello.submit("Marvin")
     print(f"variable 'future' is type {type(future)}")
+    future.wait()
 
 hello_world()
 ```
 
-When you run this code, you see that the variable `future` is a `PrefectFuture`:
+When you run this code, you see that the variable `future` is a `PrefectConcurrentFuture`:
 
 <div class="terminal">
 ```bash
-variable 'future' is type <class 'prefect.futures.PrefectFuture'>
+variable 'future' is type <class 'prefect.futures.PrefectConcurrentFuture'>
 ```
 </div>
 
 When you pass a future into a task, Prefect waits for the "upstream" task (the one that the future references), 
 to reach a final state before starting the downstream task.
 
-This means that the downstream task won't receive the `PrefectFuture` you passed as an argument. 
+This means that the downstream task won't receive the `PrefectConcurrentFuture` you passed as an argument. 
 Instead, the downstream task receives the value that the upstream task returned.
 
 For example:
@@ -229,7 +206,8 @@ def print_result(result):
 @flow(name="hello-flow")
 def hello_world():
     future = say_hello.submit("Marvin")
-    print_result.submit(future)
+    print_future = print_result.submit(future)
+    print_future.wait()
 
 hello_world()
 ```
@@ -242,7 +220,7 @@ Hello Marvin!
 </div>
 
 Futures have a few useful methods. For example, you can get the return value of the task run with 
-[`.result()`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectFuture.result):
+[`.result()`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectConcurrentFuture.result):
 
 ```python
 from prefect import flow, task
@@ -276,7 +254,7 @@ def my_task():
 def my_flow():
     future = my_task.submit()
     result = future.result(raise_on_failure=False)
-    if future.get_state().is_failed():
+    if future.state.is_failed():
         # `result` is an exception! handle accordingly
         ...
     else:
@@ -284,19 +262,22 @@ def my_flow():
         ...
 ```
 
-Retrieve the current state of the task run associated with the `PrefectFuture` using 
-[`.get_state()`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectFuture.get_state):
+Retrieve the current state of the task run associated with the `PrefectConcurrentFuture` using `.state`.
 
 ```python
+from prefect import flow
+
 @flow
 def my_flow():
     future = my_task.submit()
-    state = future.get_state()
+    state = future.state
 ```
 
-You can also wait for a task to complete by using the [`.wait()`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectFuture.wait) method:
+You can also wait for a task to complete by using the [`.wait()`](/3.0rc/api-ref/prefect/futures/#prefect.futures.PrefectConcurrentFuture.wait) method:
 
 ```python
+from prefect import flow
+
 @flow
 def my_flow():
     future = my_task.submit()
@@ -371,6 +352,7 @@ def say_nice_to_meet_you(hello_greeting):
 def hello_world():
     hello = say_hello.submit("Marvin")
     nice_to_meet_you = say_nice_to_meet_you.submit(hello)
+    nice_to_meet_you.wait()
 
 hello_world()
 ```
@@ -455,7 +437,8 @@ def do_important_stuff():
 def hello_world():
     # blocks until `say_hello` has finished
     result = say_hello.submit("Marvin").result() 
-    do_important_stuff.submit()
+    important_future = do_important_stuff.submit()
+    important_future.wait()
 
 hello_world()
 ```

--- a/src/prefect/flows.py
+++ b/src/prefect/flows.py
@@ -145,7 +145,7 @@ class Flow(Generic[P, R]):
             be provided as a string template with the flow's parameters as variables,
             or a function that returns a string.
         task_runner: An optional task runner to use for task execution within the flow;
-            if not provided, a `ConcurrentTaskRunner` will be used.
+            if not provided, a `ThreadPoolTaskRunner` will be used.
         description: An optional string description for the flow; if not provided, the
             description will be pulled from the docstring for the decorated function.
         timeout_seconds: An optional number of seconds indicating a maximum runtime for


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14144](https://togithub.com/PrefectHQ/prefect/pull/14144).



The original branch is upstream/task-runner-docs-audit