### PR TITLE
Log warning when a Concurrent, Dask, or Ray versions of `PrefectFuture` are garbage collection before resolution

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -133,18 +133,15 @@ class PrefectDaskFuture(PrefectWrappedFuture[distributed.Future]):
         return _result
 
     def __del__(self):
-        if self._final_state:
-            return
-        # make a very short attempt to check if the future has been resolved
-        self.wait(timeout=0.1)
-        if self._final_state:
+        if self._final_state or self._wrapped_future.done():
             return
         try:
             local_logger = get_run_logger()
         except Exception:
             local_logger = logger
         local_logger.warning(
-            "Future was garbage collected before it resolved. Please ensure you call `.wait()` or `.result()` to wait for the future to resolve.",
+            "A future was garbage collected before it resolved."
+            " Please call `.wait()` or `.result()` on futures to ensure they resolve.",
         )
 
 

--- a/src/integrations/prefect-ray/tests/test_task_runners.py
+++ b/src/integrations/prefect-ray/tests/test_task_runners.py
@@ -456,3 +456,36 @@ class TestRayTaskRunner:
                 e.submit(wait_for=[b_future])
 
         flow_with_dependent_tasks()
+
+    def test_warns_if_future_garbage_collection_before_resolving(
+        self, caplog, task_runner
+    ):
+        @task
+        def test_task():
+            return 42
+
+        @flow(task_runner=task_runner)
+        def test_flow():
+            for _ in range(10):
+                test_task.submit()
+
+        test_flow()
+
+        assert "A future was garbage collected before it resolved" in caplog.text
+
+    def test_does_not_warn_if_future_resolved_when_garbage_collected(
+        self, task_runner, caplog
+    ):
+        @task
+        def test_task():
+            return 42
+
+        @flow(task_runner=task_runner)
+        def test_flow():
+            futures = [test_task.submit() for _ in range(10)]
+            for future in futures:
+                future.wait()
+
+        test_flow()
+
+        assert "A future was garbage collected before it resolved" not in caplog.text


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14148](https://togithub.com/PrefectHQ/prefect/pull/14148).



The original branch is upstream/warn-on-unwaited-futures