### PR TITLE
Remove no-default-on, flow run graph experimental flags.

### DIFF
--- a/src/prefect/server/database/query_components.py
+++ b/src/prefect/server/database/query_components.py
@@ -22,7 +22,6 @@ from sqlalchemy.dialects import postgresql, sqlite
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from prefect._internal.compatibility.experimental import experiment_enabled
 from prefect.server import models, schemas
 from prefect.server.database import orm_models
 from prefect.server.exceptions import FlowRunGraphTooLarge, ObjectNotFoundError
@@ -564,9 +563,6 @@ class BaseQueryComponents(ABC):
         Does not recurse into subflows.
         Artifacts for the flow run without a task run id are grouped under None.
         """
-        if not experiment_enabled("artifacts_on_flow_run_graph"):
-            return defaultdict(list)
-
         query = (
             sa.select(
                 orm_models.Artifact,
@@ -611,9 +607,6 @@ class BaseQueryComponents(ABC):
         flow_run_id: UUID,
     ):
         """Get the flow run states for a flow run graph."""
-        if not experiment_enabled("states_on_flow_run_graph"):
-            return []
-
         flow_run_states = await models.flow_run_states.read_flow_run_states(
             session=session, flow_run_id=flow_run_id
         )

--- a/src/prefect/settings.py
+++ b/src/prefect/settings.py
@@ -1323,16 +1323,6 @@ PREFECT_API_MAX_FLOW_RUN_GRAPH_ARTIFACTS = Setting(int, default=10000)
 The maximum number of artifacts to show on a flow run graph on the v2 API
 """
 
-PREFECT_EXPERIMENTAL_ENABLE_ARTIFACTS_ON_FLOW_RUN_GRAPH = Setting(bool, default=True)
-"""
-Whether or not to enable artifacts on the flow run graph.
-"""
-
-PREFECT_EXPERIMENTAL_ENABLE_STATES_ON_FLOW_RUN_GRAPH = Setting(bool, default=True)
-"""
-Whether or not to enable flow run states on the flow run graph.
-"""
-
 PREFECT_EXPERIMENTAL_ENABLE_WORKERS = Setting(bool, default=True)
 """
 Whether or not to enable experimental Prefect workers.

--- a/tests/_internal/compatibility/test_experimental.py
+++ b/tests/_internal/compatibility/test_experimental.py
@@ -357,8 +357,6 @@ def test_enabled_experiments_with_opt_in():
         "test",
         "workers",
         "enhanced_cancellation",
-        "artifacts_on_flow_run_graph",
-        "states_on_flow_run_graph",
     }
 
 
@@ -366,6 +364,4 @@ def test_enabled_experiments_without_opt_in():
     assert enabled_experiments() == {
         "workers",
         "enhanced_cancellation",
-        "artifacts_on_flow_run_graph",
-        "states_on_flow_run_graph",
     }

--- a/tests/server/test_app.py
+++ b/tests/server/test_app.py
@@ -37,8 +37,6 @@ def test_app_exposes_ui_settings():
     assert flags == {
         "workers",
         "enhanced_cancellation",
-        "artifacts_on_flow_run_graph",
-        "states_on_flow_run_graph",
     }
     assert json == {
         "api_url": PREFECT_UI_API_URL.value(),
@@ -59,8 +57,6 @@ def test_app_exposes_ui_settings_with_experiments_enabled():
         "test",
         "workers",
         "enhanced_cancellation",
-        "artifacts_on_flow_run_graph",
-        "states_on_flow_run_graph",
     }
     assert json == {
         "api_url": PREFECT_UI_API_URL.value(),


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14217](https://togithub.com/PrefectHQ/prefect/pull/14217).



The original branch is upstream/remove-flow-run-graph-experimental-flags