### PR TITLE
Add ability to wait on or get results of groups of futures

### DIFF
--- a/src/integrations/prefect-dask/prefect_dask/task_runners.py
+++ b/src/integrations/prefect-dask/prefect_dask/task_runners.py
@@ -79,7 +79,6 @@ from typing import (
     Coroutine,
     Dict,
     Iterable,
-    List,
     Optional,
     Set,
     TypeVar,
@@ -91,7 +90,7 @@ import distributed
 from typing_extensions import ParamSpec
 
 from prefect.client.schemas.objects import State, TaskRunInput
-from prefect.futures import PrefectFuture, PrefectWrappedFuture
+from prefect.futures import PrefectFuture, PrefectFutureList, PrefectWrappedFuture
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.task_runners import TaskRunner
 from prefect.tasks import Task
@@ -366,7 +365,7 @@ class DaskTaskRunner(TaskRunner):
         task: "Task[P, Coroutine[Any, Any, R]]",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[PrefectDaskFuture[R]]:
+    ) -> PrefectFutureList[PrefectDaskFuture[R]]:
         ...
 
     @overload
@@ -375,7 +374,7 @@ class DaskTaskRunner(TaskRunner):
         task: "Task[Any, R]",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[PrefectDaskFuture[R]]:
+    ) -> PrefectFutureList[PrefectDaskFuture[R]]:
         ...
 
     def map(

--- a/src/integrations/prefect-ray/prefect_ray/task_runners.py
+++ b/src/integrations/prefect-ray/prefect_ray/task_runners.py
@@ -78,7 +78,6 @@ from typing import (
     Coroutine,
     Dict,
     Iterable,
-    List,
     Optional,
     Set,
     TypeVar,
@@ -92,7 +91,7 @@ from ray.exceptions import GetTimeoutError
 
 from prefect.client.schemas.objects import TaskRunInput
 from prefect.context import serialize_context
-from prefect.futures import PrefectFuture, PrefectWrappedFuture
+from prefect.futures import PrefectFuture, PrefectFutureList, PrefectWrappedFuture
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.states import State, exception_to_crashed_state
 from prefect.task_engine import run_task_async, run_task_sync
@@ -291,7 +290,7 @@ class RayTaskRunner(TaskRunner[PrefectRayFuture]):
         task: "Task[P, Coroutine[Any, Any, R]]",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[PrefectRayFuture[R]]:
+    ) -> PrefectFutureList[PrefectRayFuture[R]]:
         ...
 
     @overload
@@ -300,7 +299,7 @@ class RayTaskRunner(TaskRunner[PrefectRayFuture]):
         task: "Task[Any, R]",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[PrefectRayFuture[R]]:
+    ) -> PrefectFutureList[PrefectRayFuture[R]]:
         ...
 
     def map(

--- a/src/prefect/futures.py
+++ b/src/prefect/futures.py
@@ -2,8 +2,9 @@ import abc
 import concurrent.futures
 import inspect
 import uuid
+from collections.abc import Iterator
 from functools import partial
-from typing import Any, Generic, Optional, Set, Union, cast
+from typing import Any, Generic, List, Optional, Set, Union, cast
 
 from typing_extensions import TypeVar
 
@@ -16,6 +17,7 @@ from prefect.task_runs import TaskRunWaiter
 from prefect.utilities.annotations import quote
 from prefect.utilities.asyncutils import run_coro_as_sync
 from prefect.utilities.collections import StopVisiting, visit_collection
+from prefect.utilities.timeout import timeout as timeout_context
 
 F = TypeVar("F")
 R = TypeVar("R")
@@ -62,7 +64,7 @@ class PrefectFuture(abc.ABC, Generic[R]):
         If the task run has already completed, this method will return immediately.
 
         Args:
-            - timeout: The maximum number of seconds to wait for the task run to complete.
+            timeout: The maximum number of seconds to wait for the task run to complete.
               If the task run has not completed after the timeout has elapsed, this method will return.
         """
 
@@ -79,7 +81,7 @@ class PrefectFuture(abc.ABC, Generic[R]):
         If the task run has not completed, this method will wait for the task run to complete.
 
         Args:
-            - timeout: The maximum number of seconds to wait for the task run to complete.
+            timeout: The maximum number of seconds to wait for the task run to complete.
             If the task run has not completed after the timeout has elapsed, this method will return.
             - raise_on_failure: If `True`, an exception will be raised if the task run fails.
 
@@ -231,6 +233,60 @@ class PrefectDistributedFuture(PrefectFuture[R]):
         if not isinstance(other, PrefectDistributedFuture):
             return False
         return self.task_run_id == other.task_run_id
+
+
+class PrefectFutureList(list, Iterator, Generic[F]):
+    """
+    A list of Prefect futures.
+
+    This class provides methods to wait for all futures
+    in the list to complete and to retrieve the results of all task runs.
+    """
+
+    def wait_for_all(self, timeout: Optional[float] = None) -> None:
+        """
+        Wait for all futures in the list to complete.
+
+        Args:
+            timeout: The maximum number of seconds to wait for all futures to
+                complete. This method will not raise if the timeout is reached.
+        """
+        try:
+            with timeout_context(timeout):
+                for future in self:
+                    future.wait()
+        except TimeoutError:
+            logger.debug("Timed out waiting for all futures to complete.")
+            return
+
+    def results(
+        self,
+        timeout: Optional[float] = None,
+        raise_on_failure: bool = True,
+    ) -> List:
+        """
+        Get the results of all task runs associated with the futures in the list.
+
+        Args:
+            timeout: The maximum number of seconds to wait for all futures to
+                complete.
+            raise_on_failure: If `True`, an exception will be raised if any task run fails.
+
+        Returns:
+            A list of results of the task runs.
+
+        Raises:
+            TimeoutError: If the timeout is reached before all futures complete.
+        """
+        try:
+            with timeout_context(timeout):
+                return [
+                    future.result(raise_on_failure=raise_on_failure) for future in self
+                ]
+        except TimeoutError as exc:
+            raise TimeoutError(
+                f"Timed out waiting for all futures to complete within {timeout} seconds"
+            ) from exc
 
 
 def resolve_futures_to_states(

--- a/src/prefect/task_runners.py
+++ b/src/prefect/task_runners.py
@@ -25,6 +25,7 @@ from prefect.futures import (
     PrefectConcurrentFuture,
     PrefectDistributedFuture,
     PrefectFuture,
+    PrefectFutureList,
 )
 from prefect.logging.loggers import get_logger, get_run_logger
 from prefect.utilities.annotations import allow_failure, quote, unmapped
@@ -97,7 +98,7 @@ class TaskRunner(abc.ABC, Generic[F]):
         task: "Task",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[F]:
+    ) -> PrefectFutureList[F]:
         """
         Submit multiple tasks to the task run engine.
 
@@ -169,7 +170,7 @@ class TaskRunner(abc.ABC, Generic[F]):
 
         map_length = list(lengths)[0]
 
-        futures = []
+        futures: List[PrefectFuture] = []
         for i in range(map_length):
             call_parameters = {
                 key: value[i] for key, value in iterable_parameters.items()
@@ -199,7 +200,7 @@ class TaskRunner(abc.ABC, Generic[F]):
                 )
             )
 
-        return futures
+        return PrefectFutureList(futures)
 
     def __enter__(self):
         if self._started:
@@ -316,7 +317,7 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture]):
         task: "Task[P, Coroutine[Any, Any, R]]",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[PrefectConcurrentFuture[R]]:
+    ) -> PrefectFutureList[PrefectConcurrentFuture[R]]:
         ...
 
     @overload
@@ -325,7 +326,7 @@ class ThreadPoolTaskRunner(TaskRunner[PrefectConcurrentFuture]):
         task: "Task[Any, R]",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[PrefectConcurrentFuture[R]]:
+    ) -> PrefectFutureList[PrefectConcurrentFuture[R]]:
         ...
 
     def map(
@@ -427,7 +428,7 @@ class PrefectTaskRunner(TaskRunner[PrefectDistributedFuture]):
         task: "Task[P, Coroutine[Any, Any, R]]",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[PrefectDistributedFuture[R]]:
+    ) -> PrefectFutureList[PrefectDistributedFuture[R]]:
         ...
 
     @overload
@@ -436,7 +437,7 @@ class PrefectTaskRunner(TaskRunner[PrefectDistributedFuture]):
         task: "Task[Any, R]",
         parameters: Dict[str, Any],
         wait_for: Optional[Iterable[PrefectFuture]] = None,
-    ) -> List[PrefectDistributedFuture[R]]:
+    ) -> PrefectFutureList[PrefectDistributedFuture[R]]:
         ...
 
     def map(

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -43,7 +43,7 @@ from prefect.context import (
     TaskRunContext,
     serialize_context,
 )
-from prefect.futures import PrefectDistributedFuture, PrefectFuture
+from prefect.futures import PrefectDistributedFuture, PrefectFuture, PrefectFutureList
 from prefect.logging.loggers import get_logger
 from prefect.results import ResultFactory, ResultSerializer, ResultStorage
 from prefect.settings import (
@@ -991,7 +991,7 @@ class Task(Generic[P, R]):
         self: "Task[P, NoReturn]",
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> List[PrefectFuture[NoReturn]]:
+    ) -> PrefectFutureList[PrefectFuture[NoReturn]]:
         ...
 
     @overload
@@ -999,7 +999,7 @@ class Task(Generic[P, R]):
         self: "Task[P, Coroutine[Any, Any, T]]",
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> List[PrefectFuture[T]]:
+    ) -> PrefectFutureList[PrefectFuture[T]]:
         ...
 
     @overload
@@ -1007,7 +1007,7 @@ class Task(Generic[P, R]):
         self: "Task[P, T]",
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> List[PrefectFuture[T]]:
+    ) -> PrefectFutureList[PrefectFuture[T]]:
         ...
 
     @overload
@@ -1016,7 +1016,7 @@ class Task(Generic[P, R]):
         *args: P.args,
         return_state: Literal[True],
         **kwargs: P.kwargs,
-    ) -> List[State[T]]:
+    ) -> PrefectFutureList[State[T]]:
         ...
 
     @overload
@@ -1025,7 +1025,7 @@ class Task(Generic[P, R]):
         *args: P.args,
         return_state: Literal[True],
         **kwargs: P.kwargs,
-    ) -> List[State[T]]:
+    ) -> PrefectFutureList[State[T]]:
         ...
 
     def map(

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3584,6 +3584,33 @@ class TestTaskMap:
 
         await test_flow()
 
+    async def test_wait_for_all_mapped_tasks(self):
+        @task
+        def add_one(x):
+            return x + 1
+
+        @flow
+        def my_flow():
+            futures = add_one.map([1, 2, 3])
+            futures.wait_for_all()
+            for future in futures:
+                assert future.state.is_completed()
+
+        my_flow()
+
+    async def test_get_results_all_mapped_tasks(self):
+        @task
+        def add_one(x):
+            return x + 1
+
+        @flow
+        def my_flow():
+            futures = add_one.map([1, 2, 3])
+            results = futures.results()
+            assert results == [2, 3, 4]
+
+        my_flow()
+
 
 class TestTaskConstructorValidation:
     async def test_task_cannot_configure_too_many_custom_retry_delays(self):


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14234](https://togithub.com/PrefectHQ/prefect/pull/14234).



The original branch is upstream/prefect-future-list