### PR TITLE
Bump typescript from 5.4.5 to 5.5.2 in /ui

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,7 +27,7 @@
         "autoprefixer": "10.4.19",
         "eslint": "^8.57.0",
         "ts-node": "10.9.2",
-        "typescript": "^5.4.5",
+        "typescript": "^5.5.2",
         "vite": "5.3.1",
         "vue-tsc": "^2.0.21"
       }
@@ -6533,9 +6533,9 @@
       "integrity": "sha512-m9lHc3eBCJerXYdx+G0uWZihyUXdqTzzgOdqiDDsoUo75WjhFJH6vP5/6w/xhyu04zoxHUqgYhf9FEt85dk/Ng=="
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11515,9 +11515,9 @@
       "integrity": "sha512-m9lHc3eBCJerXYdx+G0uWZihyUXdqTzzgOdqiDDsoUo75WjhFJH6vP5/6w/xhyu04zoxHUqgYhf9FEt85dk/Ng=="
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
+      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
       "devOptional": true
     },
     "unbox-primitive": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "autoprefixer": "10.4.19",
     "eslint": "^8.57.0",
     "ts-node": "10.9.2",
-    "typescript": "^5.4.5",
+    "typescript": "^5.5.2",
     "vite": "5.3.1",
     "vue-tsc": "^2.0.21"
   }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14262](https://togithub.com/PrefectHQ/prefect/pull/14262).



The original branch is upstream/dependabot/npm_and_yarn/ui/typescript-5.5.2