### PR TITLE
Split Deploy/Control runs/Work pools and workers into two pages

### DIFF
--- a/docs/3.0rc/automate/add-schedules.mdx
+++ b/docs/3.0rc/automate/add-schedules.mdx
@@ -14,7 +14,7 @@ You can assign multiple schedules to deployments in the Prefect UI, or the CLI w
 the `Deployment` class, and in 
 [block-based deployment](/3.0rc/deploy/serve-flows/#block-based-deployments) YAML files.
 
-Support for multiple schedules in `flow.serve`, `flow.deploy`, `serve`, and [worker-based deployments](/3.0rc/deploy/work-pools/control-runs/) 
+Support for multiple schedules in `flow.serve`, `flow.deploy`, `serve`, and [worker-based deployments](/3.0rc/deploy/control-runs/workers/) 
 with `prefect deploy` will arrive soon.
 </Tip>
 
@@ -191,7 +191,7 @@ There are several ways to create a schedule for a deployment:
 - With the `cron`, `interval`, or `rrule` parameters if building your deployment with the 
 [`serve` method](/3.0rc/develop/write-flows/#serving-a-flow) of the `Flow` object or 
 [the `serve` utility](/3.0rc/develop/write-flows/#serving-multiple-flows-at-once) for managing multiple flows simultaneously
-- If using [worker-based deployments](/3.0rc/deploy/work-pools/control-runs/)
+- If using [worker-based deployments](/3.0rc/deploy/control-runs/workers/)
   - When you define a deployment with `flow.serve` or `flow.deploy`
   - Through the interactive `prefect deploy` command
   - With the `deployments` -> `schedules` section of the `prefect.yaml` file
@@ -268,7 +268,7 @@ timezone="America/Chicago"))
 
 ### Create schedules with the interactive `prefect deploy` command
 
-If you are using [worker-based deployments](/3.0rc/deploy/work-pools/control-runs/), you can create a schedule through the 
+If you are using [worker-based deployments](/3.0rc/deploy/control-runs/workers/), you can create a schedule through the 
 interactive `prefect deploy` command.
 
 You will be prompted to choose which type of schedule to create.

--- a/docs/3.0rc/automate/events/automations-triggers.mdx
+++ b/docs/3.0rc/automate/events/automations-triggers.mdx
@@ -17,7 +17,7 @@ Actions include starting flow runs, pausing schedules, and sending custom notifi
 - Python installed
 - Prefect [installed](/3.0rc/get-started/install/)
 - Authenticated to a [Prefect Cloud workspace](/3.0rc/get-started/quickstart/#step-2-connect-to-prefects-api/)
-- A [work pool](/3.0rc/deploy/work-pools/control-runs/) set up to handle the deployments
+- A [work pool](/3.0rc/deploy/control-runs/work-pools/) set up to handle the deployments
 
 ## Create an automation
 

--- a/docs/3.0rc/deploy/control-runs/managed-execution.mdx
+++ b/docs/3.0rc/deploy/control-runs/managed-execution.mdx
@@ -123,7 +123,7 @@ You can view your compute hours quota usage on the **Work Pools** page in the UI
 
 ## Next steps
 
-Read more about creating deployments in the [deployment guide](/3.0rc/deploy/work-pools/prefect-deploy/).
+Read more about creating deployments in the [deployment guide](/3.0rc/deploy/control-runs/prefect-deploy/).
 
 For more control over your infrastructure, such as the ability to run 
 custom Docker images, [serverless push work pools](/3.0rc/deploy/dynamic-infra/push-runs-serverless/) 

--- a/docs/3.0rc/deploy/control-runs/prefect-deploy.mdx
+++ b/docs/3.0rc/deploy/control-runs/prefect-deploy.mdx
@@ -4,6 +4,9 @@ description: Learn how to schedule and trigger flow runs through the API and eas
 ---
 
 In this guide, you will configure a deployment that uses a work pool for dynamically provisioned infrastructure.
+Work pools and workers bridge the Prefect _orchestration environment_ with your _execution environment_. 
+When a [deployment](/3.0rc/deploy/serve-flows/) creates a flow run, it is submitted to a specific work pool for scheduling. 
+A worker running in the execution environment polls its respective work pool for new runs to execute; or the work pool submits flow runs to serverless infrastructure directly, depending on your configuration.
 
 All Prefect flow runs are tracked by the API. The API does not require prior registration of flows.
 You can call a flow locally or on a remote environment and it will be trackable.
@@ -89,7 +92,7 @@ These work pool types require a worker running on your infrastructure to poll a 
     - **[Push Work Pools](/3.0rc/deploy/dynamic-infra/push-runs-serverless)**: serverless cloud options that don't require 
     a worker because Prefect Cloud submits them to your serverless cloud infrastructure on your behalf. 
     Prefect can auto-provision your cloud infrastructure for you and set it up to use your work pool.
-    - **[Managed Execution](/3.0rc/deploy/work-pools/managed-execution/)**: Prefect Cloud submits and runs your 
+    - **[Managed Execution](/3.0rc/deploy/control-runs/managed-execution/)**: Prefect Cloud submits and runs your 
     deployment on serverless infrastructure. No cloud provider account required.
 </Note>
 
@@ -100,7 +103,7 @@ and allow you to limit concurrent runs at the work pool level.
 
 When creating a deployment that uses a work pool and worker, there are two important considerations:
 
-- What instructions does a [worker](/3.0rc/deploy/work-pools/control-runs/) require to set up an execution environment for your flow? 
+- What instructions does a [worker](/3.0rc/deploy/control-runs/workers/) require to set up an execution environment for your flow? 
 For example, a flow may have Python package requirements, unique Kubernetes settings, or Docker networking configuration.
 - How should the flow code be accessed?
 
@@ -135,7 +138,7 @@ if __name__ == "__main__":
     )
 ```
 
-Make the [work pool](/3.0rc/deploy/work-pools/control-runs/) exists in the Prefect Cloud workspace you are 
+Ensure the [work pool](/3.0rc/deploy/control-runs/work-pools/) exists in the Prefect Cloud workspace you are 
 authenticated to, or on your running self-hosted server instance.  
 Then run the script to create a deployment (in future examples this step is omitted for brevity):
 
@@ -441,7 +444,7 @@ if __name__ == "__main__":
 
 The `job_variables` parameter allows you to fine-tune the infrastructure settings for a deployment.
 The values passed in override default values in the specified work pool's 
-[base job template](/3.0rc/deploy/work-pools/control-runs/#base-job-template).
+[base job template](/3.0rc/deploy/control-runs/work-pools/#base-job-template).
 
 You can override environment variables, such as `image_pull_policy` and `image`, for a specific deployment with the `job_variables` 
 argument.
@@ -1211,7 +1214,7 @@ These are fields you can add to a deployment declaration's `work_pool` section.
 | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `name`                                         | The name of the work pool to schedule flow runs in for the deployment.                                                                                                                                    |
 | <span class="no-wrap">`work_queue_name`</span> | The name of the work queue within the specified work pool to schedule flow runs in for the deployment. If not provided, the default queue for the specified work pool is used.                       |
-| `job_variables`                                | Values used to override the default values in the specified work pool's [base job template](/3.0rc/deploy/work-pools/control-runs/#base-job-template). Maps directly to a created deployments `infra_overrides` attribute. |
+| `job_variables`                                | Values used to override the default values in the specified work pool's [base job template](/3.0rc/deploy/control-runs/work-pools/#base-job-template). Maps directly to a created deployments `infra_overrides` attribute. |
 
 #### Deployment mechanics
 
@@ -1241,7 +1244,7 @@ Each time a step runs, the following actions take place in order:
 
 Now that you are familiar with creating deployments, you can explore infrastructure options for running your deployments:
 
-- [Managed work pools](/3.0rc/deploy/work-pools/managed-execution/)
+- [Managed work pools](/3.0rc/deploy/control-runs/managed-execution/)
 - [Push work pools](/3.0rc/deploy/dynamic-infra/push-runs-serverless/)
 - [Kubernetes work pools](/3.0rc/deploy/dynamic-infra/deploy-kubernetes/)
 - [Serverless hybrid work pools](/3.0rc/deploy/dynamic-infra/push-runs-remote/)

--- a/docs/3.0rc/deploy/control-runs/work-pools.mdx
+++ b/docs/3.0rc/deploy/control-runs/work-pools.mdx
@@ -1,20 +1,13 @@
 ---
-title: Work pools and  workers
-description: Prefect work pools route deployment flow runs to workers. Prefect workers poll work pools for new runs to execute.
+title: Work pools
+description: Prefect work pools route deployment flow runs to workers.
 ---
-
-Work pools and workers bridge the Prefect _orchestration environment_ with your _execution environment_. 
-When a [deployment](/3.0rc/deploy/serve-flows/) creates a flow run, it is submitted to a specific work pool for scheduling. 
-A worker running in the execution environment polls its respective work pool for new runs to execute; or the work pool  
-submits flow runs to serverless infrastructure directly, depending on your configuration.
-
-## Work pool overview
 
 Work pools organize work for execution. Work pools have types corresponding to the infrastructure to execute the flow code, 
 as well as the delivery method of work to that environment. Pull work pools require workers to poll the work 
 pool for flow runs to execute. [Push work pools](/3.0rc/deploy/dynamic-infra/push-runs-serverless) submit runs directly to your 
 serverless infrastructure providers such as Google Cloud Run, Azure Container Instances, and AWS ECS without the need for an agent or worker. 
-[Managed work pools](/3.0rc/deploy/work-pools/managed-execution) are administered by Prefect and handle the submission and execution of code on your behalf.
+[Managed work pools](/3.0rc/deploy/control-runs/managed-execution) are administered by Prefect and handle the submission and execution of code on your behalf.
 
 <Tip>
 **Work pools are like pub/sub topics**
@@ -508,161 +501,6 @@ in waterfall fashion.
     Unpausing a work queue gives the work queue a `NOT_READY` status unless a worker has polled it in the last 60 seconds.
 </Tip>
 
-## Worker overview
-
-Workers are lightweight polling services that retrieve scheduled runs from a work pool and execute them.
-
-Workers each have a type corresponding to the execution environment to submit flow runs to. Workers can only poll 
-work pools that match their type. As a result, when deployments are assigned to a work pool, you know in which execution environment 
-scheduled flow runs for that deployment will run.
-
-### Worker types
-
-Below is a list of available worker types. Most worker types require installation of an additional package.
-
-| Worker Type | Description | Required Package |
-| --- | --- | --- |
-| [`process`](https://prefect-python-sdk-docs.netlify.app/prefect/workers/process/) | Executes flow runs in subprocesses | |
-| [`kubernetes`](https://prefecthq.github.io/prefect-kubernetes/worker/) | Executes flow runs as Kubernetes jobs | `prefect-kubernetes` |
-| [`docker`](https://prefecthq.github.io/prefect-docker/worker/) | Executes flow runs within Docker containers | `prefect-docker` |
-| [`ecs`](https://prefecthq.github.io/prefect-aws/ecs_worker/) | Executes flow runs as ECS tasks | `prefect-aws` |
-| [`cloud-run`](https://prefecthq.github.io/prefect-gcp/cloud_run_worker/) | Executes flow runs as Google Cloud Run jobs | `prefect-gcp` |
-| [`vertex-ai`](https://prefecthq.github.io/prefect-gcp/vertex_worker/) | Executes flow runs as Google Cloud Vertex AI jobs | `prefect-gcp` |
-| [`azure-container-instance`](https://prefecthq.github.io/prefect-azure/container_instance_worker/) | Execute flow runs in ACI containers | `prefect-azure` |
-
-If you don’t see a worker type that meets your needs, consider 
-[developing a new worker type](/contribute/develop-a-new-worker-type/).
-
-### Worker options
-
-Workers poll for work from one or more queues within a work pool. If the worker references a work queue that doesn't exist, 
-it is created automatically. The worker CLI infers the worker type from the work pool. Alternatively, you can  
-specify the worker type explicitly. If you supply the worker type to the worker CLI, a work pool is created automatically 
-if it doesn't exist (using default job settings).
-
-Configuration parameters you can specify when starting a worker include:
-
-| Option                                            | Description                                                                                                                                 |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name`, `-n`                                    | The name to give to the started worker. If not provided, a unique name will be generated.                                                   |
-| `--pool`, `-p`                                    | The work pool the started worker should poll.                                                                                               |
-| `--work-queue`, `-q`                              | One or more work queue names for the worker to pull from. If not provided, the worker pulls from all work queues in the work pool.      |
-| `--type`, `-t`                                    | The type of worker to start. If not provided, the worker type is inferred from the work pool.                                          |
-| <span class="no-wrap">`--prefetch-seconds`</span> | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_WORKER_PREFETCH_SECONDS`. |
-| `--run-once`                                      | Only run worker polling once. By default, the worker runs forever.                                                                          |
-| `--limit`, `-l`                                   | The maximum number of flow runs to start simultaneously.                                                                                    |
-| `--with-healthcheck`                                   | Start a healthcheck server for the worker.                                                                                    |
-| `--install-policy`                                   | Install policy to use workers from Prefect integration packages.                                                                                    |
-
-You must start a worker within an environment to access or create the required infrastructure to execute flow runs. 
-The worker will deploy flow runs to the infrastructure corresponding to the worker type. For example, if you start a worker with 
-type `kubernetes`, the worker deploys flow runs to a Kubernetes cluster.
-
-Prefect must be installed in any environment (for example, virtual environment, Docker container) where you intend to run the worker or 
-execute a flow run.
-
-<Tip>
-**`PREFECT_API_URL` and `PREFECT_API_KEY`settings for workers**
-
-    `PREFECT_API_URL` must be set for the environment where your worker is running. You must also have a user or service account 
-    with the `Worker` role, which you can configure by setting the `PREFECT_API_KEY`.
-</Tip>
-
-### Worker status
-
-Workers have two statuses: `ONLINE` and `OFFLINE`. A worker is online if it sends regular heartbeat messages to the Prefect API. 
-If a worker misses three heartbeats, it is considered offline. By default, a worker is considered offline a maximum of 90 seconds 
-after it stopped sending heartbeats, but you can configure the threshold with the `PREFECT_WORKER_HEARTBEAT_SECONDS` setting.
-
-### Start a worker
-
-Use the `prefect worker start` CLI command to start a worker. You must pass at least the work pool name. 
-If the work pool does not exist, it will be created if the `--type` flag is used.
-<div class="terminal">
-```bash
-prefect worker start -p [work pool name]
-```
-</div>
-
-For example:
-<div class="terminal">
-```bash
-prefect worker start -p "my-pool"
-```
-</div>
-
-Results in output like this:
-
-<div class="terminal">
-```bash
-Discovered worker type 'process' for work pool 'my-pool'.
-Worker 'ProcessWorker 65716280-96f8-420b-9300-7e94417f2673' started!
-```
-</div>
-
-In this case, Prefect automatically discovered the worker type from the work pool.
-To create a work pool and start a worker in one command, use the `--type` flag:
-
-<div class="terminal">
-```bash
-prefect worker start -p "my-pool" --type "process"
-```
-</div>
-
-<div class="terminal">
-```bash
-Worker 'ProcessWorker d24f3768-62a9-4141-9480-a056b9539a25' started!
-06:57:53.289 | INFO    | prefect.worker.process.processworker d24f3768-62a9-4141-9480-a056b9539a25 - Worker pool 'my-pool' created.
-```
-</div>
-
-In addition, workers can limit the number of flow runs to start simultaneously with the `--limit` flag.
-For example, to limit a worker to five concurrent flow runs:
-
-<div class="terminal">
-```bash
-prefect worker start --pool "my-pool" --limit 5
-```
-</div>
-
-### Configure prefetch
-
-By default, the worker submits flow runs a short time (10 seconds) before they are scheduled to run. 
-This allows time for the infrastructure to be created so the flow run can start on time.
-
-In some cases, infrastructure takes longer than 10 seconds to start the flow run. You can increase the prefetch with the 
-`--prefetch-seconds` option or the `PREFECT_WORKER_PREFETCH_SECONDS` setting.
-
-If this value is _more_ than the amount of time it takes for the infrastructure to start, the flow run will _wait_ until its 
-scheduled start time.
-
-### Polling for work
-
-Workers poll for work every 15 seconds by default. You can configure this interval in your [profile settings](/3.0rc/manage/configure-client/) 
-with the
-`PREFECT_WORKER_QUERY_SECONDS` setting.
-
-### Install policy
-
-The Prefect CLI can install the required package for Prefect-maintained worker types automatically. Configure this behavior 
-with the `--install-policy` option. The following are valid install policies:
-
-| Install Policy | Description |
-| --- | --- |
-| `always` | Always install the required package. Updates the required package to the most recent version if already installed. |
-| `if-not-present` | Install the required package if it is not already installed. |
-| `never` | Never install the required package. |
-| `prompt` | Prompt the user to choose whether to install the required package. This is the default install policy. 
-If `prefect worker start` is run non-interactively, the `prompt` install policy behaves the same as `never`. |
-
-### Additional resources
-
-See how to [daemonize a Prefect worker](/3.0rc/deploy/dynamic-infra/push-runs-remote/).
-
-See more information on [overriding a work pool's job variables](/3.0rc/deploy/dynamic-infra/customize).
-
----------
-
 ## Benefits of work pools
 
 Work pools are a bridge between the Prefect orchestration layer and infrastructure for flow runs that can be dynamically provisioned.
@@ -692,9 +530,9 @@ Other advantages of work pools:
 
 - Configure default infrastructure configurations on your work pools that all jobs inherit and can override.
 - Allow platform teams to use work pools to expose opinionated (and enforced) interfaces to the infrastructure that they oversee.
-- Allow work pools to prioritize (or limit) flow runs through the use of [work queues](/3.0rc/deploy/work-pools/control-runs/#work-queues).
+- Allow work pools to prioritize (or limit) flow runs through the use of [work queues](/3.0rc/deploy/control-runs/work-pools/#work-queues).
 
-Prefect provides several [types of work pools](/3.0rc/deploy/work-pools/control-runs/#work-pool-types).
+Prefect provides several [types of work pools](/3.0rc/deploy/control-runs/work-pools/#work-pool-types).
 Prefect Cloud provides a Prefect Managed work pool option that is the simplest way to run workflows remotely.
 A cloud-provider account, such as AWS, is not required with a Prefect Managed work pool.
 
@@ -836,7 +674,7 @@ prefect deployment run 'get_repo_info/my-deployment'
 ```
 
 Prefect Managed work pools are a great way to get started with Prefect.  
-See the [Managed Execution guide](/3.0rc/deploy/work-pools/managed-execution) for more details.
+See the [Managed Execution guide](/3.0rc/deploy/control-runs/managed-execution) for more details.
 
 For more control over the infrastructure that your flows run on, we recommend Prefect Cloud's push work pools.
 

--- a/docs/3.0rc/deploy/control-runs/workers.mdx
+++ b/docs/3.0rc/deploy/control-runs/workers.mdx
@@ -1,0 +1,157 @@
+---
+title: Workers
+description: Prefect workers poll work pools for new runs to execute.
+---
+
+Workers are lightweight polling services that retrieve scheduled runs from a work pool and execute them.
+
+Workers each have a type corresponding to the execution environment to submit flow runs to. Workers can only poll 
+work pools that match their type. As a result, when deployments are assigned to a work pool, you know in which execution environment 
+scheduled flow runs for that deployment will run.
+
+### Worker types
+
+Below is a list of available worker types. Most worker types require installation of an additional package.
+
+| Worker Type | Description | Required Package |
+| --- | --- | --- |
+| [`process`](https://prefect-python-sdk-docs.netlify.app/prefect/workers/process/) | Executes flow runs in subprocesses | |
+| [`kubernetes`](https://prefecthq.github.io/prefect-kubernetes/worker/) | Executes flow runs as Kubernetes jobs | `prefect-kubernetes` |
+| [`docker`](https://prefecthq.github.io/prefect-docker/worker/) | Executes flow runs within Docker containers | `prefect-docker` |
+| [`ecs`](https://prefecthq.github.io/prefect-aws/ecs_worker/) | Executes flow runs as ECS tasks | `prefect-aws` |
+| [`cloud-run`](https://prefecthq.github.io/prefect-gcp/cloud_run_worker/) | Executes flow runs as Google Cloud Run jobs | `prefect-gcp` |
+| [`vertex-ai`](https://prefecthq.github.io/prefect-gcp/vertex_worker/) | Executes flow runs as Google Cloud Vertex AI jobs | `prefect-gcp` |
+| [`azure-container-instance`](https://prefecthq.github.io/prefect-azure/container_instance_worker/) | Execute flow runs in ACI containers | `prefect-azure` |
+
+If you don’t see a worker type that meets your needs, consider 
+[developing a new worker type](/contribute/develop-a-new-worker-type/).
+
+### Worker options
+
+Workers poll for work from one or more queues within a work pool. If the worker references a work queue that doesn't exist, 
+it is created automatically. The worker CLI infers the worker type from the work pool. Alternatively, you can  
+specify the worker type explicitly. If you supply the worker type to the worker CLI, a work pool is created automatically 
+if it doesn't exist (using default job settings).
+
+Configuration parameters you can specify when starting a worker include:
+
+| Option                                            | Description                                                                                                                                 |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--name`, `-n`                                    | The name to give to the started worker. If not provided, a unique name will be generated.                                                   |
+| `--pool`, `-p`                                    | The work pool the started worker should poll.                                                                                               |
+| `--work-queue`, `-q`                              | One or more work queue names for the worker to pull from. If not provided, the worker pulls from all work queues in the work pool.      |
+| `--type`, `-t`                                    | The type of worker to start. If not provided, the worker type is inferred from the work pool.                                          |
+| <span class="no-wrap">`--prefetch-seconds`</span> | The amount of time before a flow run's scheduled start time to begin submission. Default is the value of `PREFECT_WORKER_PREFETCH_SECONDS`. |
+| `--run-once`                                      | Only run worker polling once. By default, the worker runs forever.                                                                          |
+| `--limit`, `-l`                                   | The maximum number of flow runs to start simultaneously.                                                                                    |
+| `--with-healthcheck`                                   | Start a healthcheck server for the worker.                                                                                    |
+| `--install-policy`                                   | Install policy to use workers from Prefect integration packages.                                                                                    |
+
+You must start a worker within an environment to access or create the required infrastructure to execute flow runs. 
+The worker will deploy flow runs to the infrastructure corresponding to the worker type. For example, if you start a worker with 
+type `kubernetes`, the worker deploys flow runs to a Kubernetes cluster.
+
+Prefect must be installed in any environment (for example, virtual environment, Docker container) where you intend to run the worker or 
+execute a flow run.
+
+<Tip>
+**`PREFECT_API_URL` and `PREFECT_API_KEY`settings for workers**
+
+    `PREFECT_API_URL` must be set for the environment where your worker is running. You must also have a user or service account 
+    with the `Worker` role, which you can configure by setting the `PREFECT_API_KEY`.
+</Tip>
+
+### Worker status
+
+Workers have two statuses: `ONLINE` and `OFFLINE`. A worker is online if it sends regular heartbeat messages to the Prefect API. 
+If a worker misses three heartbeats, it is considered offline. By default, a worker is considered offline a maximum of 90 seconds 
+after it stopped sending heartbeats, but you can configure the threshold with the `PREFECT_WORKER_HEARTBEAT_SECONDS` setting.
+
+### Start a worker
+
+Use the `prefect worker start` CLI command to start a worker. You must pass at least the work pool name. 
+If the work pool does not exist, it will be created if the `--type` flag is used.
+<div class="terminal">
+```bash
+prefect worker start -p [work pool name]
+```
+</div>
+
+For example:
+<div class="terminal">
+```bash
+prefect worker start -p "my-pool"
+```
+</div>
+
+Results in output like this:
+
+<div class="terminal">
+```bash
+Discovered worker type 'process' for work pool 'my-pool'.
+Worker 'ProcessWorker 65716280-96f8-420b-9300-7e94417f2673' started!
+```
+</div>
+
+In this case, Prefect automatically discovered the worker type from the work pool.
+To create a work pool and start a worker in one command, use the `--type` flag:
+
+<div class="terminal">
+```bash
+prefect worker start -p "my-pool" --type "process"
+```
+</div>
+
+<div class="terminal">
+```bash
+Worker 'ProcessWorker d24f3768-62a9-4141-9480-a056b9539a25' started!
+06:57:53.289 | INFO    | prefect.worker.process.processworker d24f3768-62a9-4141-9480-a056b9539a25 - Worker pool 'my-pool' created.
+```
+</div>
+
+In addition, workers can limit the number of flow runs to start simultaneously with the `--limit` flag.
+For example, to limit a worker to five concurrent flow runs:
+
+<div class="terminal">
+```bash
+prefect worker start --pool "my-pool" --limit 5
+```
+</div>
+
+### Configure prefetch
+
+By default, the worker submits flow runs a short time (10 seconds) before they are scheduled to run. 
+This allows time for the infrastructure to be created so the flow run can start on time.
+
+In some cases, infrastructure takes longer than 10 seconds to start the flow run. You can increase the prefetch with the 
+`--prefetch-seconds` option or the `PREFECT_WORKER_PREFETCH_SECONDS` setting.
+
+If this value is _more_ than the amount of time it takes for the infrastructure to start, the flow run will _wait_ until its 
+scheduled start time.
+
+### Polling for work
+
+Workers poll for work every 15 seconds by default. You can configure this interval in your [profile settings](/3.0rc/manage/configure-client/) 
+with the
+`PREFECT_WORKER_QUERY_SECONDS` setting.
+
+### Install policy
+
+The Prefect CLI can install the required package for Prefect-maintained worker types automatically. Configure this behavior 
+with the `--install-policy` option. The following are valid install policies:
+
+| Install Policy | Description |
+| --- | --- |
+| `always` | Always install the required package. Updates the required package to the most recent version if already installed. |
+| `if-not-present` | Install the required package if it is not already installed. |
+| `never` | Never install the required package. |
+| `prompt` | Prompt the user to choose whether to install the required package. This is the default install policy. 
+If `prefect worker start` is run non-interactively, the `prompt` install policy behaves the same as `never`. |
+
+### Additional resources
+
+See how to [daemonize a Prefect worker](/3.0rc/deploy/dynamic-infra/push-runs-remote/).
+
+See more information on [overriding a work pool's job variables](/3.0rc/deploy/dynamic-infra/customize).
+
+---------

--- a/docs/3.0rc/deploy/dynamic-infra/deploy-docker.mdx
+++ b/docs/3.0rc/deploy/dynamic-infra/deploy-docker.mdx
@@ -386,10 +386,10 @@ Prefect is installed into a conda environment named `prefect`.
 If your flow relies on dependencies not found in the default `prefecthq/prefect` images, 
 you may want to build your own image. You can either
 base it off of one of the provided `prefecthq/prefect` images, or build your own image.
-See the [Work pool deployment guide](/3.0rc/deploy/work-pools/prefect-deploy) 
+See the [Work pool deployment guide](/3.0rc/deploy/control-runs/prefect-deploy) 
 to build custom images with dependencies specified in a `requirements.txt` file.
 
-By default, Prefect [work pools](/3.0rc/deploy/work-pools/control-runs) 
+By default, Prefect [work pools](/3.0rc/deploy/control-runs/work-pools) 
 that use containers refer to the `3-latest` image.
 You can specify another image at work pool creation.
 You can override the work pool image choice in individual deployments.
@@ -436,4 +436,4 @@ different configuration](/3.0rc/develop/write-flows#serving-multiple-flows-at-on
 - To learn more about deploying flows, check out the [Deployments](/3.0rc/deploy/serve-flows/) 
 concept doc.
 - For advanced infrastructure requirements, such as executing each flow run within its own dedicated 
-Docker container, learn more in the [Work pool deployment guide](/3.0rc/deploy/work-pools/prefect-deploy).
+Docker container, learn more in the [Work pool deployment guide](/3.0rc/deploy/control-runs/prefect-deploy).

--- a/docs/3.0rc/deploy/dynamic-infra/deploy-kubernetes.mdx
+++ b/docs/3.0rc/deploy/dynamic-infra/deploy-kubernetes.mdx
@@ -183,7 +183,7 @@ If you already have a registry, skip ahead to the next section.
 
 ## Create a Kubernetes work pool
 
-[Work pools](3.0rc/deploy/work-pools/control-runs/) allow you to manage deployment 
+[Work pools](3.0rc/deploy/control-runs/work-pools/) allow you to manage deployment 
 infrastructure.
 This section shows you how to configure the default values for your 
 Kubernetes base job template.

--- a/docs/3.0rc/deploy/dynamic-infra/push-runs-remote.mdx
+++ b/docs/3.0rc/deploy/dynamic-infra/push-runs-remote.mdx
@@ -39,7 +39,7 @@ graph TD
 <Tip>
 Notice above that the worker is in charge of provisioning the _flow run infrastructure_.
 In the context of this tutorial, that flow run infrastructure is an ephemeral Docker container to host each flow run.
-Different [worker types](/3.0rc/deploy/work-pools/control-runs/#worker-types) create different types of flow run 
+Different [worker types](/3.0rc/deploy/control-runs/workers/#worker-types) create different types of flow run 
 infrastructure.
 </Tip>
 
@@ -55,7 +55,7 @@ client to execute all work sent to this pool inside a dedicated Docker container
 <Tip>
 **Other work pool types**
 
-There are [work pool types](/3.0rc/deploy/work-pools/control-runs/#worker-types) for serverless computing 
+There are [work pool types](/3.0rc/deploy/control-runs/work-pools/#work-pool-types) for serverless computing 
 environments such as AWS ECS, Azure Container Instances, Google Cloud Run, and Vertex AI.
 Kubernetes is also a popular work pool type.
 </Tip>
@@ -222,7 +222,7 @@ To update your deployment, modify your script and rerun it. Specify a value for 
 so your Docker worker can successfully execute scheduled runs for this flow. See the example below.
 
 The `job_variables` section allows you to fine-tune the infrastructure settings for a specific deployment. These values override 
-default values in the specified work pool's [base job template](/3.0rc/deploy/work-pools/control-runs/#base-job-template).
+default values in the specified work pool's [base job template](/3.0rc/deploy/control-runs/work-pools/#base-job-template).
 
 When testing images locally without pushing them to a registry (to avoid potential errors like docker.errors.NotFound), 
 we recommend including an `image_pull_policy` job_variable set to `Never`. However, for production workflows, push images to a 
@@ -288,7 +288,7 @@ prefect deployment run 'get_repo_info/my-deployment'
 
 ## Learn more
 
-- Learn how to configure deployments in YAML with [`prefect.yaml`](/3.0rc/deploy/work-pools/prefect-deploy/).
+- Learn how to configure deployments in YAML with [`prefect.yaml`](/3.0rc/deploy/control-runs/prefect-deploy/).
 - [Deploy flows on Kubernetes](/3.0rc/deploy/dynamic-infra/deploy-kubernetes/)
 - [Deploy flows in Docker](/3.0rc/deploy/dynamic-infra/deploy-docker/)
 - [Deploy flows on serverless infrastructure](/3.0rc/deploy/dynamic-infra/push-runs-remote/)
@@ -346,10 +346,10 @@ levels.
 
 ## Next steps
 
-Learn more about [workers and work pools](/3.0rc/deploy/work-pools/control-runs/).
+Learn more about [work pools](/3.0rc/deploy/control-runs/work-pools/) and [workers](/3.0rc/deploy/control-runs/workers/).
 
 Learn about installing dependencies at runtime or baking them into your Docker image in the 
-[work pools and workers guide](/3.0rc/deploy/work-pools/prefect-deploy/#creating-work-pool-based-deployments-with-deploy).
+[work pools and workers guide](/3.0rc/deploy/control-runs/prefect-deploy/#creating-work-pool-based-deployments-with-deploy).
 
 To set up a long-lived process on a Windows machine the pattern is similar.
 Instead of systemd, you can use [NSSM](https://nssm.cc/).

--- a/docs/3.0rc/deploy/dynamic-infra/push-runs-serverless.mdx
+++ b/docs/3.0rc/deploy/dynamic-infra/push-runs-serverless.mdx
@@ -3,7 +3,7 @@ title: Push work to serverless computing infrastructure
 description: Learn how to use Prefect push work pools to schedule work on serverless infrastructure without having to run a worker.
 ---
 
-Push [work pools](/3.0rc/deploy/work-pools/control-runs/#work-pool-overview) are a special type of work pool. They allow 
+Push [work pools](/3.0rc/deploy/control-runs/work-pools/) are a special type of work pool. They allow 
 Prefect Cloud to submit flow runs for execution to serverless computing infrastructure without requiring you to run a worker.
 Push work pools currently support execution in AWS ECS tasks, Azure Container Instances, Google Cloud Run jobs, and Modal.
 
@@ -659,7 +659,7 @@ Click **Create** to configure your push work pool by selecting a push option in 
   <Tab title="AWS ECS">
 
     Each step has several optional fields that are detailed in the
-     [work pools documentation](/3.0rc/deploy/work-pools/control-runs/). 
+     [work pools documentation](/3.0rc/deploy/control-runs/work-pools/). 
     Select the block you created under the AWS Credentials field. 
     This allows Prefect Cloud to securely interact with your ECS cluster.
  </Tab>
@@ -671,14 +671,14 @@ Click **Create** to configure your push work pool by selecting a push option in 
  <Tab title="Google Cloud Run">
 
     Each step has several optional fields that are detailed in the 
-    [work pools guide](/3.0rc/deploy/work-pools/control-runs/). 
+    [work pools guide](/3.0rc/deploy/control-runs/work-pools/). 
     Select the block you created under the GCP Credentials field. 
     This allows Prefect Cloud to securely interact with your GCP project.
  </Tab>
  <Tab title="Modal">
 
     Each step has several optional fields that are detailed in the 
-    [work pools documentation](/3.0rc/deploy/work-pools/control-runs/). 
+    [work pools documentation](/3.0rc/deploy/control-runs/work-pools/). 
     Select the block you created under the Modal Credentials field. 
     This allows Prefect Cloud to securely interact with your Modal account.
  </Tab>
@@ -717,7 +717,7 @@ to your serverless infrastructure, created a job, ran the job, and reported on i
 
 ## Next steps
 
-Learn more about [workers and work pools](/3.0rc/deploy/work-pools/control-runs/).
+Learn more about [work pools](/3.0rc/deploy/control-runs/work-pools/) and [workers](/3.0rc/deploy/control-runs/workers/).
 
 Learn about installing dependencies at runtime or baking them into your Docker image in the [Deploying flows to work 
-pools and workers](/3.0rc/deploy/work-pools/prefect-deploy/#creating-work-pool-based-deployments-with-deploy) guide.
+pools and workers](/3.0rc/deploy/control-runs/prefect-deploy/#creating-work-pool-based-deployments-with-deploy) guide.

--- a/docs/3.0rc/deploy/dynamic-infra/retrieve-flow-code.mdx
+++ b/docs/3.0rc/deploy/dynamic-infra/retrieve-flow-code.mdx
@@ -9,7 +9,7 @@ Flow code is not stored in a Prefect server instance or in Prefect Cloud.
 You have several flow code storage options.
 
 This guide focuses on deployments created with the interactive CLI experience or a prefect.yaml file. 
-To create deployments with Python code, see the [work pools and workers guide](/3.0rc/deploy/work-pools/prefect-deploy/#creating-work-pool-based-deployments-with-deploy).
+To create deployments with Python code, see the [work pools and workers guide](/3.0rc/deploy/control-runs/prefect-deploy/#creating-work-pool-based-deployments-with-deploy).
 
 
 ## Option 1: Git-based storage
@@ -292,7 +292,7 @@ Below are the recipe options and the relevant portions of the `prefect.yaml` fil
     </Tab>
 </Tabs>
 
-Another authentication option is to give the [worker](/3.0rc/deploy/work-pools/control-runs/#worker-overview) access 
+Another authentication option is to give the [worker](/3.0rc/deploy/control-runs/workers/) access 
 to the storage location at runtime through SSH keys.
 
 Alternatively, you can inject environment variables into your deployment. See this example that uses an environment variable named 

--- a/docs/3.0rc/deploy/serve-flows/deploy-a-flow.mdx
+++ b/docs/3.0rc/deploy/serve-flows/deploy-a-flow.mdx
@@ -381,7 +381,7 @@ anytime the flow or task runs, allowing you to audit changes.
 
 ### Workers and work pools
 
-[Workers and work pools](/3.0rc/deploy/work-pools/control-runs/) are an advanced deployment pattern that 
+[Work pools](/3.0rc/deploy/control-runs/work-pools/) and [workers](/3.0rc/deploy/control-runs/workers/) are an advanced deployment pattern that 
 allow you to dynamically provision infrastructure for each flow run.
 The work pool job template interface allows users to create and govern opinionated interfaces 
 to their workflow infrastructure.
@@ -435,7 +435,7 @@ infrastructure with work pools under these circumstances:
 - If your internal team structure requires that deployment authors be members of a different team 
 than the team managing infrastructure.
 
-[Work pools](/3.0rc/deploy/work-pools/control-runs/) allow Prefect to exercise greater control 
+[Work pools](/3.0rc/deploy/control-runs/work-pools/) allow Prefect to exercise greater control 
 of the infrastructure on which flows run.
 Options for [serverless work pools](/3.0rc/deploy/dynamic-infra/push-runs-remote/) allow you to 
 scale to zero when workflows aren't running.

--- a/docs/3.0rc/get-started/quickstart.mdx
+++ b/docs/3.0rc/get-started/quickstart.mdx
@@ -146,13 +146,13 @@ Prefect automatically tracks the state of the flow run and logs the output in th
 ## Create a work pool
 
 Running a flow locally is a good start, but you should use a remote destination for production flows.
-A [work pool](/3.0rc/deploy/work-pools/control-runs/) is the most common way to do this.
+A [work pool](/3.0rc/deploy/control-runs/work-pools/) is the most common way to do this.
 
 <Tabs>
   <Tab title="Prefect Cloud">
 Deploy your flow to Cloud using a managed work pool.
 
-1. Create a [managed work pool](/3.0rc/deploy/work-pools/control-runs):
+1. Create a [managed work pool](/3.0rc/deploy/control-runs/work-pools):
 
    ```bash
    prefect work-pool create my-work-pool --type prefect:managed

--- a/docs/3.0rc/manage/cloud/index.mdx
+++ b/docs/3.0rc/manage/cloud/index.mdx
@@ -45,7 +45,7 @@ A workspace is an isolated environment within Prefect Cloud for all Prefect acti
 - [Flow runs](/3.0rc/develop/write-flows/) and task runs executed in an environment that is [syncing with the workspace](/3.0rc/manage/cloud/workspaces/)
 - [Flows](/3.0rc/develop/write-flows/) associated with flow runs and deployments observed by the Prefect Cloud API
 - [Deployments](/3.0rc/deploy/serve-flows/)
-- [Work pools](/3.0rc/deploy/work-pools/control-runs/)
+- [Work pools](/3.0rc/deploy/control-runs/work-pools/)
 - [Blocks](/3.0rc/develop/blocks/)
 - [Events](/3.0rc/automate/events/)
 - [Automations](/3.0rc/automate/events/automations-triggers/)

--- a/docs/3.0rc/manage/configure-client.mdx
+++ b/docs/3.0rc/manage/configure-client.mdx
@@ -60,7 +60,7 @@ PREFECT_API_URL="http://127.0.0.1:4200/api"
 
 **`PREFECT_API_URL` setting for workers**
 
-If you're using a [worker](/3.0rc/deploy/work-pools/control-runs/) to run flows in remote environments, 
+If you're using a [worker](/3.0rc/deploy/control-runs/workers/) to run flows in remote environments, 
 [`PREFECT_API_URL`](/3.0rc/manage/configure-client/) must be set for the environment where your worker is running.
 
 For the worker to communicate with Prefect Cloud or a Prefect server instance from a remote execution environment such as a VM or 

--- a/docs/3.0rc/resources/daemonize-processes.mdx
+++ b/docs/3.0rc/resources/daemonize-processes.mdx
@@ -27,7 +27,7 @@ AWS Linux image, you can install Python and pip with `sudo yum install -y python
 
 A systemd service is ideal for running a long-lived process on a Linux VM or physical Linux server.
 You will use systemd and learn how to automatically start a
-[Prefect worker](/3.0rc/deploy/work-pools/control-runs/#worker-overview) or
+[Prefect worker](/3.0rc/deploy/control-runs/workers/) or
 long-lived [`serve` process](/3.0rc/develop/write-flows/#serving-a-flow) when Linux starts.
 This approach provides resilience by automatically restarting the process if it crashes.
 

--- a/docs/3.0rc/resources/secrets.mdx
+++ b/docs/3.0rc/resources/secrets.mdx
@@ -182,7 +182,7 @@ See [`prefect-snowflake`](/integrations/prefect-snowflake) for more examples of 
 
 ## Next steps
 
-Now you can turn your flow into a [deployment](/3.0rc/deploy/work-pools/prefect-deploy/) so you and your team 
+Now you can turn your flow into a [deployment](/3.0rc/deploy/control-runs/prefect-deploy/) so you and your team 
 can run it remotely on a schedule, in response to an event, or manually.  
 
 Make sure to specify the `prefect-aws` and `prefect-snowflake` dependencies in your work pool or deployment 

--- a/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
+++ b/docs/3.0rc/resources/upgrade-agents-to-workers.mdx
@@ -21,7 +21,7 @@ If you are new to Prefect, we recommend starting with the
 </Note>
 
 ## About workers and agents
-A [worker](/3.0rc/deploy/work-pools/control-runs/#worker-overview) is the fusion of an 
+A [worker](/3.0rc/deploy/control-runs/workers/) is the fusion of an 
 agent with an infrastructure block. 
 Like agents, workers poll a work pool for flow runs that are scheduled to start. 
 Like infrastructure blocks, workers are typed. They work with only one kind of infrastructure, 
@@ -30,7 +30,7 @@ and they specify the default configuration for jobs submitted to that infrastruc
 Accordingly, workers are not a drop-in replacement for agents. **Using workers requires 
 deploying flows differently.** In particular, deploying a flow with a worker does not involve 
 specifying an infrastructure block. Instead, infrastructure configuration is specified on the 
-[work pool](/3.0rc/deploy/work-pools/control-runs/) and passed to each worker that polls work 
+[work pool](/3.0rc/deploy/control-runs/work-pools/) and passed to each worker that polls work 
 from that pool.
 
 ## Upgrade enhancements
@@ -44,10 +44,10 @@ and when it last polled.
 ### Work pools
 
 - Work pools allow greater customization and governance of infrastructure parameters for deployments 
-through their [base job template](/3.0rc/deploy/work-pools/control-runs/#base-job-template).
+through their [base job template](/3.0rc/deploy/control-runs/work-pools/#base-job-template).
 - Prefect Cloud [push work pools](/3.0rc/deploy/dynamic-infra/push-runs-serverless/) enable flow 
 execution in your cloud provider environment without the need to host a worker.
-- Prefect Cloud [managed work pools](/3.0rc/deploy/work-pools/managed-execution/) allow you to run flows on 
+- Prefect Cloud [managed work pools](/3.0rc/deploy/control-runs/managed-execution/) allow you to run flows on 
 Prefect's infrastructure, without the need to host a worker or configure cloud provider infrastructure.
 
 ### Improved deployment interfaces
@@ -77,14 +77,14 @@ to enable [dryer deployment definitions](/3.0rc/deploy/serve-flows/#reusing-conf
 
     When using the YAML-based deployment API, you can configure a pull action in your `prefect.yaml` 
     file to specify how to retrieve flow code for your deployments. You can use configuration from your 
-    existing storage blocks to define your pull action [through templating](/3.0rc/deploy/work-pools/prefect-deploy/#templating-options).
+    existing storage blocks to define your pull action [through templating](/3.0rc/deploy/control-runs/prefect-deploy/#templating-options).
 
     When using the Python deployment API, you can pass any storage block to the `flow.deploy` method to 
     specify how to retrieve flow code for your deployment.
 
 3. **Configuring flow run infrastructure:**
 
-    infrastructure blocks --> [typed work pool](/3.0rc/deploy/work-pools/control-runs/#worker-types)
+    infrastructure blocks --> [typed work pool](/3.0rc/deploy/control-runs/workers/#worker-types)
 
     Default infrastructure config is now set on the typed work pool, and can be overwritten by 
     individual deployments.
@@ -104,7 +104,7 @@ to enable [dryer deployment definitions](/3.0rc/deploy/serve-flows/#reusing-conf
 
     `infra_override` -> [`job_variable`](/3.0rc/deploy/serve-flows/#work-pool-fields)
 
-- The process for starting an agent and [starting a worker](/3.0rc/deploy/work-pools/control-runs/#starting-a-worker) 
+- The process for starting an agent and [starting a worker](/3.0rc/deploy/control-runs/workers/#start-a-worker) 
 in your environment are virtually identical.
 
     `prefect agent start --pool <work pool name>` --> `prefect worker start --pool <work pool name>`
@@ -122,7 +122,7 @@ to host workers in your cluster.
 If you have existing deployments that use infrastructure blocks, you can quickly upgrade them to 
 be compatible with workers by following these steps:
 
-1. **[Create a work pool](/3.0rc/deploy/work-pools/control-runs/#work-pool-configuration)**
+1. **[Create a work pool](/3.0rc/deploy/control-runs/work-pools/#work-pool-configuration)**
 
 This new work pool replaces your infrastructure block.
 
@@ -155,7 +155,7 @@ Check out our [Docker guide](/3.0rc/deploy/dynamic-infra/deploy-docker/) for how
 served flow into a Docker image and host it in your environment.
 </Tip>
 
-2. **[Start a worker](/3.0rc/deploy/work-pools/control-runs/#starting-a-worker)**
+2. **[Start a worker](/3.0rc/deploy/control-runs/workers/#start-a-worker)**
 
 This worker replaces your agent and polls your new work pool for flow runs to execute.
 
@@ -387,4 +387,4 @@ You can add more [deployments](/3.0rc/deploy/serve-flows/#deployment-declaration
 to the `deployments` list in your `prefect.yaml` file and/or by continuing to use the deployment 
 creation wizard.
 
-For more information on deployments, check out our [in-depth guide for deploying flows to work pools](/3.0rc/deploy/work-pools/prefect-deploy/).
+For more information on deployments, check out our [in-depth guide for deploying flows to work pools](/3.0rc/deploy/control-runs/prefect-deploy/).

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -149,9 +149,10 @@
           "group": "Control runs",
           "version": "3.0rc",
           "pages": [
-            "3.0rc/deploy/work-pools/control-runs",
-            "3.0rc/deploy/work-pools/prefect-deploy",
-            "3.0rc/deploy/work-pools/managed-execution"
+            "3.0rc/deploy/control-runs/work-pools",
+            "3.0rc/deploy/control-runs/workers",
+            "3.0rc/deploy/control-runs/prefect-deploy",
+            "3.0rc/deploy/control-runs/managed-execution"
           ]
         }
       ]


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14298](https://togithub.com/PrefectHQ/prefect/pull/14298).



The original branch is upstream/split_the_deploy_work_pools_and_workers_into_two_pages