### PR TITLE
adding move warning to moved_in_v3 for get_client

### DIFF
--- a/src/prefect/_internal/compatibility/migration.py
+++ b/src/prefect/_internal/compatibility/migration.py
@@ -27,6 +27,7 @@ MOVED_IN_V3 = {
     "prefect.engine:resume_flow_run": "prefect.flow_runs:resume_flow_run",
     "prefect.engine:suspend_flow_run": "prefect.flow_runs:suspend_flow_run",
     "prefect.engine:_in_process_pause": "prefect.flow_runs:_in_process_pause",
+    "prefect.client:get_client": "prefect.client.orchestration:get_client",
 }
 
 REMOVED_IN_V3 = {

--- a/src/prefect/client/__init__.py
+++ b/src/prefect/client/__init__.py
@@ -15,3 +15,7 @@ $ python -m asyncio
 ```
 </div>
 """
+
+from prefect._internal.compatibility.migration import getattr_migration
+
+__getattr__ = getattr_migration(__name__)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14299](https://togithub.com/PrefectHQ/prefect/pull/14299).



The original branch is upstream/client-move-warning