### PR TITLE
Made Azure ACI infra names consistent regardless of flow name length

### DIFF
--- a/src/integrations/prefect-azure/prefect_azure/workers/container_instance.py
+++ b/src/integrations/prefect-azure/prefect_azure/workers/container_instance.py
@@ -554,17 +554,15 @@ class AzureContainerWorker(BaseWorker):
         # Get the flow, so we can use its name in the container group name
         # to make it easier to identify and debug.
         flow = await prefect_client.read_flow(flow_run.flow_id)
-        container_group_name = f"{flow.name}-{flow_run.id}"
 
-        # Slugify flow.name if the generated name will be too long for the
-        # max deployment name length (64) including "prefect-"
-        if len(container_group_name) > 55:
-            slugified_flow_name = slugify(
-                flow.name,
-                max_length=55 - len(str(flow_run.id)),
-                regex_pattern=r"[^a-zA-Z0-9-]+",
-            )
-            container_group_name = f"{slugified_flow_name}-{flow_run.id}"
+        # Slugify flow.name and ensure that the generated name won't be too long
+        # for the max deployment name length (64) including "prefect-"
+        slugified_flow_name = slugify(
+            flow.name,
+            max_length=55 - len(str(flow_run.id)),
+            regex_pattern=r"[^a-zA-Z0-9-]+",
+        )
+        container_group_name = f"{slugified_flow_name}-{flow_run.id}"
 
         self._logger.info(
             f"{self._log_prefix}: Preparing to run command {configuration.command} "


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14333](https://togithub.com/PrefectHQ/prefect/pull/14333).



The original branch is fork-14333-bjorhn/azure-consistent-aci-infra-names