### PR TITLE
allow passing custom timeout exception type to disambiguate

### DIFF
--- a/src/prefect/task_engine.py
+++ b/src/prefect/task_engine.py
@@ -80,6 +80,10 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
+class TaskRunTimeoutError(TimeoutError):
+    """Raised when a task run exceeds its timeout."""
+
+
 @dataclass
 class TaskRunEngine(Generic[P, R]):
     task: Union[Task[P, R], Task[P, Coroutine[Any, Any, R]]]
@@ -397,9 +401,12 @@ class TaskRunEngine(Generic[P, R]):
 
     def handle_timeout(self, exc: TimeoutError) -> None:
         if not self.handle_retry(exc):
-            message = (
-                f"Task run exceeded timeout of {self.task.timeout_seconds} seconds"
-            )
+            if isinstance(exc, TaskRunTimeoutError):
+                message = (
+                    f"Task run exceeded timeout of {self.task.timeout_seconds} seconds"
+                )
+            else:
+                message = f"Task run failed due to timeout: {exc!r}"
             self.logger.error(message)
             state = Failed(
                 data=exc,
@@ -612,7 +619,10 @@ class TaskRunEngine(Generic[P, R]):
         # reenter the run context to ensure it is up to date for every run
         with self.setup_run_context():
             try:
-                with timeout_context(seconds=self.task.timeout_seconds):
+                with timeout_context(
+                    seconds=self.task.timeout_seconds,
+                    timeout_exc_type=TaskRunTimeoutError,
+                ):
                     self.logger.debug(
                         f"Executing task {self.task.name!r} for task run {self.task_run.name!r}..."
                     )

--- a/src/prefect/utilities/timeout.py
+++ b/src/prefect/utilities/timeout.py
@@ -8,10 +8,19 @@ from prefect._internal.concurrency.cancellation import (
 )
 
 
+def fail_if_not_timeout_error(timeout_exc_type: Type[Exception]) -> None:
+    if not issubclass(timeout_exc_type, TimeoutError):
+        raise ValueError(
+            "The `timeout_exc_type` argument must be a subclass of `TimeoutError`."
+        )
+
+
 @contextmanager
 def timeout_async(
     seconds: Optional[float] = None, timeout_exc_type: Type[TimeoutError] = TimeoutError
 ):
+    fail_if_not_timeout_error(timeout_exc_type)
+
     if seconds is None:
         yield
         return
@@ -27,6 +36,8 @@ def timeout_async(
 def timeout(
     seconds: Optional[float] = None, timeout_exc_type: Type[TimeoutError] = TimeoutError
 ):
+    fail_if_not_timeout_error(timeout_exc_type)
+
     if seconds is None:
         yield
         return

--- a/src/prefect/utilities/timeout.py
+++ b/src/prefect/utilities/timeout.py
@@ -1,6 +1,6 @@
 from asyncio import CancelledError
 from contextlib import contextmanager
-from typing import Optional
+from typing import Optional, Type
 
 from prefect._internal.concurrency.cancellation import (
     cancel_async_after,
@@ -9,7 +9,9 @@ from prefect._internal.concurrency.cancellation import (
 
 
 @contextmanager
-def timeout_async(seconds: Optional[float] = None):
+def timeout_async(
+    seconds: Optional[float] = None, timeout_exc_type: Type[TimeoutError] = TimeoutError
+):
     if seconds is None:
         yield
         return
@@ -18,11 +20,13 @@ def timeout_async(seconds: Optional[float] = None):
         with cancel_async_after(timeout=seconds):
             yield
     except CancelledError:
-        raise TimeoutError(f"Scope timed out after {seconds} second(s).")
+        raise timeout_exc_type(f"Scope timed out after {seconds} second(s).")
 
 
 @contextmanager
-def timeout(seconds: Optional[float] = None):
+def timeout(
+    seconds: Optional[float] = None, timeout_exc_type: Type[TimeoutError] = TimeoutError
+):
     if seconds is None:
         yield
         return
@@ -31,4 +35,4 @@ def timeout(seconds: Optional[float] = None):
         with cancel_sync_after(timeout=seconds):
             yield
     except CancelledError:
-        raise TimeoutError(f"Scope timed out after {seconds} second(s).")
+        raise timeout_exc_type(f"Scope timed out after {seconds} second(s).")

--- a/tests/utilities/test_timeout.py
+++ b/tests/utilities/test_timeout.py
@@ -20,3 +20,10 @@ async def test_timeout_raises_custom_error_type_async():
     with pytest.raises(CustomTimeoutError):
         with timeout_async(seconds=0.1, timeout_exc_type=CustomTimeoutError):
             await asyncio.sleep(1)
+
+
+@pytest.mark.parametrize("timeout_context", [timeout, timeout_async])
+def test_timeout_raises_if_non_timeout_exception_type_passed(timeout_context):
+    with pytest.raises(ValueError, match="must be a subclass of `TimeoutError`"):
+        with timeout_context(timeout_exc_type=Exception):
+            pass

--- a/tests/utilities/test_timeout.py
+++ b/tests/utilities/test_timeout.py
@@ -1,0 +1,22 @@
+import asyncio
+import time
+
+import pytest
+
+from prefect.utilities.timeout import timeout, timeout_async
+
+
+class CustomTimeoutError(TimeoutError):
+    ...
+
+
+def test_timeout_raises_custom_error_type_sync():
+    with pytest.raises(CustomTimeoutError):
+        with timeout(seconds=0.1, timeout_exc_type=CustomTimeoutError):
+            time.sleep(1)
+
+
+async def test_timeout_raises_custom_error_type_async():
+    with pytest.raises(CustomTimeoutError):
+        with timeout_async(seconds=0.1, timeout_exc_type=CustomTimeoutError):
+            await asyncio.sleep(1)


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14352](https://togithub.com/PrefectHQ/prefect/pull/14352).



The original branch is upstream/disambiguate-timeouts