### PR TITLE
Fix error when returning from task and flows with `cache_result_in_memory=False`

### DIFF
--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -998,6 +998,38 @@ class TestFlowCall:
                 def bar():
                     pass
 
+    def test_returns_when_cache_result_in_memory_is_false_sync_flow(self):
+        @flow(cache_result_in_memory=False)
+        def my_flow():
+            return 42
+
+        assert my_flow() == 42
+
+    async def test_returns_when_cache_result_in_memory_is_false_async_flow(self):
+        @flow(cache_result_in_memory=False)
+        async def my_flow():
+            return 42
+
+        assert await my_flow() == 42
+
+    def test_raises_correct_error_when_cache_result_in_memory_is_false_sync_flow(self):
+        @flow(cache_result_in_memory=False)
+        def my_flow():
+            raise ValueError("Test")
+
+        with pytest.raises(ValueError, match="Test"):
+            my_flow()
+
+    async def test_raises_correct_error_when_cache_result_in_memory_is_false_async_flow(
+        self,
+    ):
+        @flow(cache_result_in_memory=False)
+        async def my_flow():
+            raise ValueError("Test")
+
+        with pytest.raises(ValueError, match="Test"):
+            await my_flow()
+
 
 class TestSubflowCalls:
     async def test_subflow_call_with_no_tasks(self):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -487,6 +487,38 @@ class TestTaskCall:
                 def bar():
                     pass
 
+    def test_returns_when_cache_result_in_memory_is_false_sync_task(self):
+        @task(cache_result_in_memory=False)
+        def my_task():
+            return 42
+
+        assert my_task() == 42
+
+    async def test_returns_when_cache_result_in_memory_is_false_async_task(self):
+        @task(cache_result_in_memory=False)
+        async def my_task():
+            return 42
+
+        assert await my_task() == 42
+
+    def test_raises_correct_error_when_cache_result_in_memory_is_false_sync_task(self):
+        @task(cache_result_in_memory=False)
+        def my_task():
+            raise ValueError("Test")
+
+        with pytest.raises(ValueError, match="Test"):
+            my_task()
+
+    async def test_raises_correct_error_when_cache_result_in_memory_is_false_async_task(
+        self,
+    ):
+        @task(cache_result_in_memory=False)
+        async def my_task():
+            raise ValueError("Test")
+
+        with pytest.raises(ValueError, match="Test"):
+            await my_task()
+
 
 class TestTaskRun:
     async def test_sync_task_run_inside_sync_flow(self):


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14359](https://togithub.com/PrefectHQ/prefect/pull/14359).



The original branch is upstream/fix-return-when-results-not-cached