### PR TITLE
Emit task run urls when creating/submitting background tasks

### DIFF
--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -1310,9 +1310,10 @@ class Task(Generic[P, R]):
             )
         )  # type: ignore
 
-        logger.info(
-            f"Created task run {task_run.name!r}. View it in the UI at {url_for(task_run)!r}"
-        )
+        if task_run_url := url_for(task_run):
+            logger.info(
+                f"Created task run {task_run.name!r}. View it in the UI at {task_run_url!r}"
+            )
 
         return PrefectDistributedFuture(task_run_id=task_run.id)
 

--- a/src/prefect/tasks.py
+++ b/src/prefect/tasks.py
@@ -66,6 +66,7 @@ from prefect.utilities.callables import (
 )
 from prefect.utilities.hashing import hash_objects
 from prefect.utilities.importtools import to_qualified_name
+from prefect.utilities.urls import url_for
 
 if TYPE_CHECKING:
     from prefect.client.orchestration import PrefectClient
@@ -1300,14 +1301,19 @@ class Task(Generic[P, R]):
         # Convert the call args/kwargs to a parameter dict
         parameters = get_call_parameters(self.fn, args, kwargs)
 
-        task_run = run_coro_as_sync(
+        task_run: TaskRun = run_coro_as_sync(
             self.create_run(
                 parameters=parameters,
                 deferred=True,
                 wait_for=wait_for,
                 extra_task_inputs=dependencies,
             )
+        )  # type: ignore
+
+        logger.info(
+            f"Created task run {task_run.name!r}. View it in the UI at {url_for(task_run)!r}"
         )
+
         return PrefectDistributedFuture(task_run_id=task_run.id)
 
     def delay(self, *args: P.args, **kwargs: P.kwargs) -> PrefectDistributedFuture:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -39,6 +39,7 @@ from prefect.settings import (
     PREFECT_DEBUG_MODE,
     PREFECT_TASK_DEFAULT_RETRIES,
     PREFECT_TASKS_REFRESH_CACHE,
+    PREFECT_UI_URL,
     temporary_settings,
 )
 from prefect.states import State
@@ -4978,6 +4979,16 @@ class TestApplyAsync:
             "x": [TaskRunResult(id=task_run_id)],
             "y": [],
         }
+
+    def test_apply_async_emits_run_ui_url(self, caplog):
+        @task
+        def add(x, y):
+            return x + y
+
+        with temporary_settings({PREFECT_UI_URL: "http://test/api"}):
+            add.apply_async((42, 42))
+
+        assert "in the UI at 'http://test/api/runs/task-run/" in caplog.text
 
 
 class TestDelay:


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14407](https://togithub.com/PrefectHQ/prefect/pull/14407).



The original branch is upstream/emit-background-task-urls