### PR TITLE
fix `truncate_to` bug that results in the original string being returned

### DIFF
--- a/src/prefect/utilities/text.py
+++ b/src/prefect/utilities/text.py
@@ -8,12 +8,8 @@ def truncated_to(length: int, value: Optional[str]) -> str:
     if len(value) <= length:
         return value
 
-    half = length // 2
+    help_text = "...[truncated]..."
 
-    beginning = value[:half]
-    end = value[-half:]
-    omitted = len(value) - (len(beginning) + len(end))
+    truncated = value[: length - len(help_text)]
 
-    proposed = f"{beginning}...{omitted} additional characters...{end}"
-
-    return proposed if len(proposed) < len(value) else value
+    return truncated + help_text if len(truncated) < len(help_text) else value[:length]

--- a/src/prefect/utilities/text.py
+++ b/src/prefect/utilities/text.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+HELP_TEXT = "...[truncated]..."
+
 
 def truncated_to(length: int, value: Optional[str]) -> str:
     if not value:
@@ -8,8 +10,8 @@ def truncated_to(length: int, value: Optional[str]) -> str:
     if len(value) <= length:
         return value
 
-    help_text = "...[truncated]..."
-
-    truncated = value[: length - len(help_text)]
-
-    return truncated + help_text if len(truncated) < len(help_text) else value[:length]
+    return (
+        value[: length - len(HELP_TEXT)] + HELP_TEXT
+        if len(HELP_TEXT) < length
+        else value[:length]
+    )

--- a/tests/utilities/test_text.py
+++ b/tests/utilities/test_text.py
@@ -1,0 +1,29 @@
+from prefect.utilities.text import HELP_TEXT, truncated_to
+
+
+class TestTruncatedTo:
+    def test_empty_value(self):
+        value = None
+        length = 100
+        trunc = truncated_to(length, value)
+        assert trunc == ""
+
+    def test_length_exceeds_value(self):
+        value = "a" * 50
+        length = 51
+        trunc = truncated_to(length, value)
+        assert trunc == value
+
+    def test_normal_truncation(self):
+        value = "a" * 100
+        length = 50
+        trunc = truncated_to(length, value)
+        assert len(trunc) == length
+        assert trunc.endswith(HELP_TEXT)
+
+    def test_truncation_help_text_too_long(self):
+        value = "a" * 100
+        length = 10
+        trunc = truncated_to(length, value)
+        assert len(trunc) == length
+        assert trunc == "a" * length


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#11046](https://togithub.com/PrefectHQ/prefect/pull/11046).



The original branch is fork-11046-Jellyfish-AI/patch-truncate-function