### PR TITLE
Bump typescript from 5.5.2 to 5.5.3 in /ui

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -27,7 +27,7 @@
         "autoprefixer": "10.4.19",
         "eslint": "^8.57.0",
         "ts-node": "10.9.2",
-        "typescript": "^5.5.2",
+        "typescript": "^5.5.3",
         "vite": "5.3.2",
         "vue-tsc": "^2.0.24"
       }
@@ -6571,9 +6571,9 @@
       "integrity": "sha512-m9lHc3eBCJerXYdx+G0uWZihyUXdqTzzgOdqiDDsoUo75WjhFJH6vP5/6w/xhyu04zoxHUqgYhf9FEt85dk/Ng=="
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -11588,9 +11588,9 @@
       "integrity": "sha512-m9lHc3eBCJerXYdx+G0uWZihyUXdqTzzgOdqiDDsoUo75WjhFJH6vP5/6w/xhyu04zoxHUqgYhf9FEt85dk/Ng=="
     },
     "typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.3.tgz",
+      "integrity": "sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==",
       "devOptional": true
     },
     "unbox-primitive": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "autoprefixer": "10.4.19",
     "eslint": "^8.57.0",
     "ts-node": "10.9.2",
-    "typescript": "^5.5.2",
+    "typescript": "^5.5.3",
     "vite": "5.3.2",
     "vue-tsc": "^2.0.24"
   }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14499](https://togithub.com/PrefectHQ/prefect/pull/14499).



The original branch is upstream/dependabot/npm_and_yarn/ui/typescript-5.5.3