### PR TITLE
Excludes the pdoc search index JS file from CodeQL

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -5,3 +5,4 @@ query-filters:
 
 paths-ignore:
   - tests/**/test_*.py
+  - docs/**/search.js


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [PrefectHQ/prefect#14558](https://togithub.com/PrefectHQ/prefect/pull/14558).



The original branch is upstream/clear-codeql-warning